### PR TITLE
Adds unit testing + a few improvements to gmx.go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+install:
+- go get github.com/mattn/goveralls
+
+script:
+- go test -v -coverprofile=coverage.out
+- $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: go
 
 install:
+- go get github.com/google/go-github/github
 - go get github.com/mattn/goveralls
+- go get github.com/prometheus/client_golang/prometheus
+- go get github.com/prometheus/client_golang/prometheus/promhttp
 
 script:
 - go test -v -coverprofile=coverage.out

--- a/gmx.go
+++ b/gmx.go
@@ -298,8 +298,8 @@ func receiveHook(resp http.ResponseWriter, req *http.Request) {
 			return
 		}
 	case *github.PingEvent:
-		log.Println("INFO: Received an Ping event.")
-		var cnt int
+		log.Println("INFO: Webhook is a Ping event.")
+		var cnt = 0
 		// Since this exporter only processes "issues" and "issue_comment" Github
 		// webhook events, be sure that at least these two events are enabled for the
 		// webhook.
@@ -307,9 +307,9 @@ func receiveHook(resp http.ResponseWriter, req *http.Request) {
 			if v == "issues" || v == "issue_comment" {
 				cnt++
 			}
-
 		}
 		if cnt != 2 {
+			log.Printf("ERROR: Registered webhook events do not include both 'issues' and 'issue_comment'.")
 			status = http.StatusExpectationFailed
 		}
 	default:

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
@@ -42,22 +41,18 @@ func TestRestoreState(t *testing.T) {
 	expectedMachines := 3
 	expectedSites := 4
 
-	r := bufio.NewReader(strings.NewReader(savedState))
-	testState := maintenanceState{
-		Machines: make(map[string]string),
-		Sites:    make(map[string]string),
-	}
+	r := strings.NewReader(savedState)
+	var s maintenanceState
+	restoreState(r, &s)
 
-	restoreState(r, &testState)
-
-	if len(testState.Machines) != expectedMachines {
+	if len(s.Machines) != expectedMachines {
 		t.Errorf("restoreState(): Expected %d restored machines; have %d.",
-			expectedMachines, len(testState.Machines))
+			expectedMachines, len(s.Machines))
 	}
 
-	if len(testState.Sites) != expectedSites {
+	if len(s.Sites) != expectedSites {
 		t.Errorf("restoreState(): Expected %d restored sites; have %d.",
-			expectedSites, len(testState.Sites))
+			expectedSites, len(s.Sites))
 	}
 }
 
@@ -179,14 +174,11 @@ func TestReceiveHook(t *testing.T) {
 func TestCloseIssue(t *testing.T) {
 	expectedMods := 3
 
-	r := bufio.NewReader(strings.NewReader(savedState))
-	testState := maintenanceState{
-		Machines: make(map[string]string),
-		Sites:    make(map[string]string),
-	}
-	restoreState(r, &testState)
+	r := strings.NewReader(savedState)
+	var s maintenanceState
+	restoreState(r, &s)
 
-	mods := closeIssue("8", &testState)
+	mods := closeIssue("8", &s)
 
 	if mods != expectedMods {
 		t.Errorf("closeIssue(): Expected %d state modifications; got %d", expectedMods, mods)
@@ -194,12 +186,9 @@ func TestCloseIssue(t *testing.T) {
 }
 
 func TestParseMessage(t *testing.T) {
-	r := bufio.NewReader(strings.NewReader(savedState))
-	testState := maintenanceState{
-		Machines: make(map[string]string),
-		Sites:    make(map[string]string),
-	}
-	restoreState(r, &testState)
+	r := strings.NewReader(savedState)
+	var s maintenanceState
+	restoreState(r, &s)
 
 	tests := []struct {
 		name         string
@@ -234,7 +223,7 @@ func TestParseMessage(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mods := parseMessage(test.msg, "99", &testState)
+		mods := parseMessage(test.msg, "99", &s)
 		if mods != test.expectedMods {
 			t.Errorf("parseMessage(): %s: expected %d state modifications; got %d",
 				test.name, test.expectedMods, mods)

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -100,11 +100,56 @@ func TestReceiveHook(t *testing.T) {
 			payload:        []byte(`{"fake":"data"}`),
 		},
 		{
+			name:           "issues-hook-good-request-2-mods",
+			secretKey:      githubSecret,
+			eventType:      "issues",
+			expectedStatus: http.StatusOK,
+			payload: []byte(`
+				{
+					"action": "edited",
+					"issue": {
+						"number": 3,
+						"body": "Put /machine mlab1.abc01 and /site xyz01 into maintenance."
+					}
+				}
+			`),
+		},
+		{
+			name:           "issues-hook-good-request-close-issue",
+			secretKey:      githubSecret,
+			eventType:      "issues",
+			expectedStatus: http.StatusOK,
+			payload: []byte(`
+				{
+					"action": "closed",
+					"issue": {
+						"number": 3,
+						"body": "Issue resolved."
+					}
+				}
+			`),
+		},
+		{
 			name:           "issue-comment-hook-malformed-payload",
 			secretKey:      githubSecret,
 			eventType:      "issue_comment",
 			expectedStatus: http.StatusBadRequest,
 			payload:        []byte(`"malformed; 'json }]]}`),
+		},
+		{
+			name:           "issue-hook-good-request-1-mod",
+			secretKey:      githubSecret,
+			eventType:      "issue_comment",
+			expectedStatus: http.StatusOK,
+			payload: []byte(`
+				{
+					"action": "edited",
+					"issue": {
+						"number": 1,
+						"body": "Take /machine mlab1.abc01 del out of maintenance."
+					}
+				}
+			`),
 		},
 	}
 

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
@@ -10,10 +11,51 @@ import (
 	"testing"
 )
 
+// Sample maintenance state as written to disk in JSON format.
+var savedState = `
+	{
+		"Machines": {
+			"mlab1.abc01.measurement-lab.org": "1",
+			"mlab2.xyz01.measurement-lab.org": "2",
+			"mlab3.def01.measurement-lab.org": "3"
+		},
+		"Sites": {
+			"abc02": "3",
+			"def02": "3",
+			"uvw03": "4",
+			"xyz03": "5"
+
+		}
+	}
+`
+
 func generateSignature(secret, msg []byte) string {
 	mac := hmac.New(sha1.New, secret)
 	mac.Write(msg)
 	return "sha1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestRestoreState(t *testing.T) {
+	expectedMachines := 3
+	expectedSites := 4
+
+	r := bufio.NewReader(strings.NewReader(savedState))
+	testState := maintenanceState{
+		Machines: make(map[string]string),
+		Sites:    make(map[string]string),
+	}
+
+	restoreState(r, &testState)
+
+	if len(testState.Machines) != expectedMachines {
+		t.Errorf("restoreState(): Expected %d restored machines; have %d.",
+			expectedMachines, len(testState.Machines))
+	}
+
+	if len(testState.Sites) != expectedSites {
+		t.Errorf("restoreState(): Expected %d restored sites; have %d.",
+			expectedSites, len(testState.Sites))
+	}
 }
 
 func TestReceiveHook(t *testing.T) {
@@ -48,16 +90,24 @@ func TestReceiveHook(t *testing.T) {
 			secretKey:      []byte("badsecret"),
 			eventType:      "issues",
 			expectedStatus: http.StatusUnauthorized,
-			payload:        []byte(`{"key":"value"}`),
+			payload:        []byte(`{"fake":"data"}`),
+		},
+		{
+			name:           "issues-hook-unsupported-event-type",
+			secretKey:      githubSecret,
+			eventType:      "pull_request",
+			expectedStatus: http.StatusNotImplemented,
+			payload:        []byte(`{"fake":"data"}`),
 		},
 		{
 			name:           "issue-comment-hook-malformed-payload",
 			secretKey:      githubSecret,
 			eventType:      "issue_comment",
 			expectedStatus: http.StatusBadRequest,
-			payload:        []byte(`{ "malformed; 'json }]]}`),
+			payload:        []byte(`"malformed; 'json }]]}`),
 		},
 	}
+
 	for _, test := range tests {
 		sig := generateSignature(test.secretKey, test.payload)
 		req, err := http.NewRequest("POST", "/webhook", strings.NewReader(string(test.payload)))
@@ -75,6 +125,65 @@ func TestReceiveHook(t *testing.T) {
 		if status := rec.Code; status != test.expectedStatus {
 			t.Errorf("receiveHook(): test %s: wrong HTTP status: got %v; want %v",
 				test.name, rec.Code, test.expectedStatus)
+		}
+	}
+}
+
+func TestCloseIssue(t *testing.T) {
+	expectedMods := 3
+
+	r := bufio.NewReader(strings.NewReader(savedState))
+	testState := maintenanceState{
+		Machines: make(map[string]string),
+		Sites:    make(map[string]string),
+	}
+	restoreState(r, &testState)
+
+	mods := closeIssue("3", &testState)
+
+	if mods != expectedMods {
+		t.Errorf("closeIssue(): Expected %d state modifications; got %d", expectedMods, mods)
+	}
+}
+
+func TestParseMessage(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(savedState))
+	testState := maintenanceState{
+		Machines: make(map[string]string),
+		Sites:    make(map[string]string),
+	}
+	restoreState(r, &testState)
+
+	tests := []struct {
+		msg          string
+		expectedMods int
+	}{
+		{
+			msg:          `/machine mlab1.abc01 is in maintenance mode.`,
+			expectedMods: 1,
+		},
+		{
+			msg:          `Putting /site abc01 and /site xyz02 into maintenance mode.`,
+			expectedMods: 2,
+		},
+		{
+			msg:          `Putting /site abc01 and /machine mlab1.xyz02 into maintenance mode.`,
+			expectedMods: 2,
+		},
+		{
+			msg:          `Removing /machine mlab2.xyz01 del and /site uvw02 del from maintenance.`,
+			expectedMods: 2,
+		},
+		{
+			msg:          `Add /machine and /site vw02 to maintenance. Removing /site lol del.`,
+			expectedMods: 0,
+		},
+	}
+
+	for _, test := range tests {
+		mods := parseMessage(test.msg, "99", &testState)
+		if mods != test.expectedMods {
+			t.Errorf("parseMessage(): Expected %d state modifications; got %d", test.expectedMods, mods)
 		}
 	}
 }

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func generateSignature(secret, msg []byte) string {
+	mac := hmac.New(sha1.New, secret)
+	mac.Write(msg)
+	return "sha1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestReceiveHook(t *testing.T) {
+	githubSecret = []byte("goodsecret")
+
+	tests := []struct {
+		name           string
+		secretKey      []byte
+		eventType      string
+		expectedStatus int
+		payload        []byte
+	}{
+		{
+			name:           "ping-hook-wrong-events-registered",
+			secretKey:      githubSecret,
+			eventType:      "ping",
+			expectedStatus: http.StatusExpectationFailed,
+			payload: []byte(`
+				{
+					"hook": {
+				 		"type": "App",
+				  		"id": 11,
+				  		"active": true,
+				  		"events": ["issues", "label", "pull_request"],
+					  	"app_id":37
+					}
+				}
+			`),
+		},
+		{
+			name:           "issues-hook-bad-signature",
+			secretKey:      []byte("badsecret"),
+			eventType:      "issues",
+			expectedStatus: http.StatusUnauthorized,
+			payload:        []byte(`{"key":"value"}`),
+		},
+		{
+			name:           "issue-comment-hook-malformed-payload",
+			secretKey:      githubSecret,
+			eventType:      "issue_comment",
+			expectedStatus: http.StatusBadRequest,
+			payload:        []byte(`{ "malformed; 'json }]]}`),
+		},
+	}
+	for _, test := range tests {
+		sig := generateSignature(test.secretKey, test.payload)
+		req, err := http.NewRequest("POST", "/webhook", strings.NewReader(string(test.payload)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GitHub-Event", test.eventType)
+		req.Header.Set("X-Hub-Signature", sig)
+
+		rec := httptest.NewRecorder()
+		handler := http.HandlerFunc(receiveHook)
+		handler.ServeHTTP(rec, req)
+
+		if status := rec.Code; status != test.expectedStatus {
+			t.Errorf("receiveHook(): test %s: wrong HTTP status: got %v; want %v",
+				test.name, rec.Code, test.expectedStatus)
+		}
+	}
+}


### PR DESCRIPTION
The main feature of this PR is the addition of unit tests. Coverage is currently at about 80%.

* In gmx.go, we are now passing `io.Writers` and `io.Readers` to `restoreState` and `writeState` which makes unit testing easier, and is likely a better implementation anyway.
* `writeState()` is now only called from a single place in the code, and we only write state when something actually changed.
* `parseMessage()` and `closeIssue()` now return an `int` with the number of state modifications that were made instead of an `error`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/6)
<!-- Reviewable:end -->
