### PR TITLE
Sets GitHub webhook secret from environment by default

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -238,7 +238,7 @@ func parseMessage(msg string, issueNumber string, s *maintenanceState) int {
 	return mods
 }
 
-// rootHanlder implements the simplest possible handler for root requests,
+// rootHandler implements the simplest possible handler for root requests,
 // simply printing the name of the utility and returning a 200 status. This
 // could be used by, for example, kubernetes aliveness checks.
 func rootHandler(resp http.ResponseWriter, req *http.Request) {
@@ -379,6 +379,10 @@ func main() {
 		secretFile.Close()
 	} else {
 		githubSecret = []byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))
+	}
+
+	if len(githubSecret) == 0 {
+		log.Fatal("No GitHub webhook secret found.")
 	}
 
 	http.HandleFunc("/", rootHandler)

--- a/gmx.go
+++ b/gmx.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -237,6 +238,15 @@ func parseMessage(msg string, issueNumber string, s *maintenanceState) int {
 	return mods
 }
 
+// rootHanlder implements the simplest possible handler for root requests,
+// simply printing the name of the utility and returning a 200 status. This
+// could be used by, for example, kubernetes aliveness checks.
+func rootHandler(resp http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(resp, "GitHub Maintenance Exporter")
+	resp.WriteHeader(http.StatusOK)
+	return
+}
+
 // receiveHook is the handler function for received webhooks. It validates the
 // hook, parses the payload, makes sure that the hook event matches at least one
 // event this exporter handles, then passes off the payload to parseMessage.
@@ -328,7 +338,7 @@ func init() {
 		"Address to listen on for telemetry.")
 	flag.StringVar(&fStateFilePath, "storage.state-file", "/tmp/gmx-state",
 		"Filesystem path for the state file.")
-	flag.StringVar(&fGitHubSecretPath, "storage.github-secret", "github-secret",
+	flag.StringVar(&fGitHubSecretPath, "storage.github-secret", "",
 		"Filesystem path of file containing the shared Github webhook secret.")
 	prometheus.MustRegister(metricError)
 	prometheus.MustRegister(metricMachine)
@@ -347,24 +357,31 @@ func main() {
 	}
 	stateFile.Close()
 
-	secretFile, err := os.Open(fGitHubSecretPath)
-	if err != nil {
-		log.Printf("ERROR: Failed to open secret file %s: %s", fGitHubSecretPath, err)
-		os.Exit(1)
+	// If provided, read the GitHub shared webhook secret from a file, else expect to
+	// find it in the environment.
+	if fGitHubSecretPath != "" {
+		secretFile, err := os.Open(fGitHubSecretPath)
+		if err != nil {
+			log.Printf("ERROR: Failed to open secret file %s: %s", fGitHubSecretPath, err)
+			os.Exit(1)
+		}
+		secret, err := ioutil.ReadAll(secretFile)
+		if err != nil {
+			log.Printf("ERROR: Failed to read secret file %s: %s", fGitHubSecretPath, err)
+			os.Exit(1)
+		}
+		secretTrimmed := bytes.TrimSpace(secret)
+		if len(secretTrimmed) == 0 {
+			log.Printf("ERROR: Github secret file %s is empty.", fGitHubSecretPath)
+			os.Exit(1)
+		}
+		githubSecret = secretTrimmed
+		secretFile.Close()
+	} else {
+		githubSecret = []byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))
 	}
-	secret, err := ioutil.ReadAll(secretFile)
-	if err != nil {
-		log.Printf("ERROR: Failed to read secret file %s: %s", fGitHubSecretPath, err)
-		os.Exit(1)
-	}
-	secretTrimmed := bytes.TrimSpace(secret)
-	if len(secretTrimmed) == 0 {
-		log.Printf("ERROR: Github secret file %s is empty.", fGitHubSecretPath)
-		os.Exit(1)
-	}
-	githubSecret = secretTrimmed
-	secretFile.Close()
 
+	http.HandleFunc("/", rootHandler)
 	http.HandleFunc("/webhook", receiveHook)
 	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(fListenAddress, nil))

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -35,6 +36,30 @@ func generateSignature(secret, msg []byte) string {
 	mac := hmac.New(sha1.New, secret)
 	mac.Write(msg)
 	return "sha1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestRootHandler(t *testing.T) {
+	expectedStatus := http.StatusOK
+	expectedPayload := "GitHub Maintenance Exporter"
+
+	req, err := http.NewRequest("POST", "/", strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	rootHandler(rec, req)
+
+	if status := rec.Code; status != expectedStatus {
+		t.Errorf("rootHandler(): test %s: wrong HTTP status: got %v; want %v",
+			"TestRootHandler", rec.Code, expectedStatus)
+	}
+
+	bytes, _ := ioutil.ReadAll(rec.Body)
+	payload := string(bytes)
+	if string(payload) != expectedPayload {
+		t.Errorf("rootHandler(): test %s: unexpected return text: got %s; want %s",
+			"TestRootHandler", payload, expectedPayload)
+	}
 }
 
 func TestRestoreState(t *testing.T) {

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -49,7 +49,7 @@ func TestRootHandler(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rootHandler(rec, req)
 
-	if status := rec.Code; status != expectedStatus {
+	if rec.Code != expectedStatus {
 		t.Errorf("rootHandler(): test %s: wrong HTTP status: got %v; want %v",
 			"TestRootHandler", rec.Code, expectedStatus)
 	}


### PR DESCRIPTION
If the flag `fGitHubSecretPath` is specified, it will read from that file instead of from the environment.

For our purposes, I think it will be easier to put the GitHub secret key into a k8s secret and then put it into the environment rather than using a ConfigMap and mounting it into the container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/10)
<!-- Reviewable:end -->
