### PR TITLE
Suppresses the addition of a newline char from echo.

### DIFF
--- a/deploy_gmx.sh
+++ b/deploy_gmx.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 
 # Write secret to a file to prevent printing secret in travis logs.
-( set +x; echo "${GITHUB_WEBHOOK_SECRET}" > /tmp/gmx-webhook-secret )
+( set +x; echo -n "${GITHUB_WEBHOOK_SECRET}" > /tmp/gmx-webhook-secret )
 
 # Create a k8s secret for the GitHub webhook shared secret.
 kubectl create secret generic gmx-webhook-secret \


### PR DESCRIPTION
`echo` was adding a `\n` char to the end of the string, thus corrupting the k8s secret with an unintended character, causing Github webhooks to fail validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/12)
<!-- Reviewable:end -->
