### PR TITLE
Fixes a bug where measurement-lab.org was being appended to metric labels.

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -159,7 +159,7 @@ func closeIssue(issueNumber string, s *maintenanceState) int {
 	for machine, issue := range s.Machines {
 		if issue == issueNumber {
 			delete(s.Machines, machine)
-			metricMachine.WithLabelValues(machine+".measurement-lab.org", issueNumber).Set(0)
+			metricMachine.WithLabelValues(machine, issueNumber).Set(0)
 			log.Printf("INFO: Machine %s was removed from maintenance because issue was closed.", machine)
 			mods++
 		}


### PR DESCRIPTION
At some point in the past, the label `machine` for GMX metrics only contained the short name of a machine (e.g., `mlab2.den01`). For various reason, short names were abandoned and the `machine` label started using the FQDN of the machine.   This PR fixes a bug in the `closeIssue()` function that was appending `.measurement-lab.org` to an already FQDN, which was, of course, causing unexpected behavior. This PR fixes this bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/13)
<!-- Reviewable:end -->
