### PR TITLE
Fixes duplicate maintenance bug from issue #17

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -201,8 +201,8 @@ func updateState(stateMap map[string]string, mapKey string, metricState *prometh
 		metricError.WithLabelValues("duplicatemaintenance", "updateState").Add(1)
 	case cEnterMaintenance:
 		// Do not create a maintenance entry if one already exists for a site or machine.
-		for _, issue := range stateMap {
-			if issue == issueNumber {
+		for entity, _ := range stateMap {
+			if entity == mapKey {
 				log.Printf("ERROR: %s is already in maintenance mode.", mapKey)
 				metricError.WithLabelValues("duplicatemaintenance", "updateState").Add(1)
 				return

--- a/gmx.go
+++ b/gmx.go
@@ -189,8 +189,8 @@ func updateState(stateMap map[string]string, mapKey string, metricState *prometh
 	case cLeaveMaintenance:
 		// Only remove a maintenance entry if this request is coming from the issue
 		// that created the maintenance entry.
-		for maintenanceEntity, issue := range stateMap {
-			if stateMap[maintenanceEntity] == issueNumber:
+		for _, issue := range stateMap {
+			if issue == issueNumber {
 				delete(stateMap, mapKey)
 				metricState.WithLabelValues(mapKey, issueNumber).Set(action)
 				log.Printf("INFO: %s was removed from maintenance.", mapKey)
@@ -201,8 +201,8 @@ func updateState(stateMap map[string]string, mapKey string, metricState *prometh
 		metricError.WithLabelValues("duplicatemaintenance", "updateState").Add(1)
 	case cEnterMaintenance:
 		// Do not create a maintenance entry if one already exists for a site or machine.
-		for maintenanceEntity, issue := range stateMap {
-			if stateMap[maintenanceEntity] == issueNumber:
+		for _, issue := range stateMap {
+			if issue == issueNumber {
 				log.Printf("ERROR: %s is already in maintenance mode.", mapKey)
 				metricError.WithLabelValues("duplicatemaintenance", "updateState").Add(1)
 				return


### PR DESCRIPTION
I believe this should correct issue #17. However, one noteworthy thing is that an operator adding a duplicate GMX status for a site or machine will not be aware that it didn't work, unless we were to create some sort of alert on:

`gmx_error_count{function="updateState",type="duplicatemaintenance"}`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/18)
<!-- Reviewable:end -->
