### PR TITLE
Allow multiple issues to hold a site/machine in maintenance mode at the same time

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -167,10 +167,10 @@ func removeIssue(stateMap map[string][]string, mapKey string, metricState *prome
 		if len(mapElement) == 0 {
 			delete(stateMap, mapKey)
 			metricState.WithLabelValues(mapKey).Set(0)
-			log.Printf("INFO: %s was removed from maintenance.", mapKey)
 		} else {
 			stateMap[mapKey] = mapElement
 		}
+		log.Printf("INFO: %s was removed from maintenance for issue #%s", mapKey, issueNumber)
 		mods++
 	}
 	return mods
@@ -216,7 +216,7 @@ func updateState(stateMap map[string][]string, mapKey string, metricState *prome
 	case cEnterMaintenance:
 		stateMap[mapKey] = append(stateMap[mapKey], issueNumber)
 		metricState.WithLabelValues(mapKey).Set(action)
-		log.Printf("INFO: %s was added to maintenance.", mapKey)
+		log.Printf("INFO: %s was added to maintenance for issue #%s", mapKey, issueNumber)
 	default:
 		log.Printf("WARNING: Unknown action type: %f", action)
 	}

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -15,15 +15,15 @@ import (
 var savedState = `
 	{
 		"Machines": {
-			"mlab1.abc01.measurement-lab.org": "1",
-			"mlab2.xyz01.measurement-lab.org": "2",
-			"mlab3.def01.measurement-lab.org": "8"
+			"mlab1.abc01.measurement-lab.org": ["1"],
+			"mlab2.xyz01.measurement-lab.org": ["2"],
+			"mlab3.def01.measurement-lab.org": ["8"]
 		},
 		"Sites": {
-			"abc02": "8",
-			"def02": "8",
-			"uvw03": "4",
-			"xyz03": "5"
+			"abc02": ["8"],
+			"def02": ["8"],
+			"uvw03": ["4"],
+			"xyz03": ["5"]
 
 		}
 	}

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -22,7 +22,7 @@ var savedState = `
 		"Sites": {
 			"abc02": ["8"],
 			"def02": ["8"],
-			"uvw03": ["4"],
+			"uvw03": ["4", "11"],
 			"xyz03": ["5"]
 
 		}
@@ -229,16 +229,46 @@ func TestReceiveHook(t *testing.T) {
 }
 
 func TestCloseIssue(t *testing.T) {
-	expectedMods := 3
 
-	r := strings.NewReader(savedState)
-	var s maintenanceState
-	restoreState(r, &s)
+	tests := []struct {
+		name              string
+		issue             string
+		expectedMods      int
+		closedMaintenance int
+	}{
+		{
+			name:              "one-issue-per-entity-closes-maintenance",
+			issue:             "8",
+			expectedMods:      3,
+			closedMaintenance: 3,
+		},
+		{
+			name:              "multiple-issues-per-entity-does-not-close-maintenance",
+			issue:             "4",
+			expectedMods:      1,
+			closedMaintenance: 0,
+		},
+	}
 
-	mods := closeIssue("8", &s)
+	for _, test := range tests {
+		r := strings.NewReader(savedState)
+		var s maintenanceState
+		restoreState(r, &s)
 
-	if mods != expectedMods {
-		t.Errorf("closeIssue(): Expected %d state modifications; got %d", expectedMods, mods)
+		totalEntitiesBefore := len(s.Machines) + len(s.Sites)
+		mods := closeIssue(test.issue, &s)
+		totalEntitiesAfter := len(s.Machines) + len(s.Sites)
+		closedMaintenance := totalEntitiesBefore - totalEntitiesAfter
+
+		if mods != test.expectedMods {
+			t.Errorf("closeIssue(): Expected %d state modifications; got %d",
+				test.expectedMods, mods)
+		}
+
+		if closedMaintenance != test.closedMaintenance {
+			t.Errorf("closeIssue(): Expected %d closed maintenances; got %d",
+				test.closedMaintenance, closedMaintenance)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR should resolve issue #17.

GMX was originally designed with the intention that no more than a single issue would ever have a site/machine in maintenance at the same time. And if such a situation arose, the behavior was undefined. It turns out that that undefined behavior can be defined as: the newer issue putting a site/machine into maintenance would usurp the maintenance for that site/machine and leave an orphaned Prometheus timeseries that would would also be `1`. This meant that queries would return two records for a single entity, both with a value of 1.

This PR, formally introduces the ability for multiple issues to hold maintenance on any given site/machine. GMX will keep maintenance open on the site/machine until all issues which put it into maintenance are either remove it or are closed.

This PR also changes the metric labels by removing the `issue` label. The issue label was problematic because it created an entirely new timeseries for every issue-site/machine that was ever put into maintenance mode. This meant that a Prom query to find the maintenance status of a given site/machine would also return records for all of the old maintenances, and this was complicating queries and dashboard panels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/19)
<!-- Reviewable:end -->
