### PR TITLE
Fixes `multiple response.WriteHeader calls` bug + fixes fault regexps

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -52,15 +52,15 @@ var (
 	mux sync.Mutex
 
 	machineRegExps = map[string]*regexp.Regexp{
-		"mlab-sandbox": regexp.MustCompile(`\/machine\s+(mlab[1-4]\.[a-z]{3}[0-9]t)\s+(del)?`),
-		"mlab-staging": regexp.MustCompile(`\/machine\s+(mlab[4]\.[a-z]{3}[0-9c]{2})\s+(del)?`),
-		"mlab-oti":     regexp.MustCompile(`\/machine\s+(mlab[1-3]\.[a-z]{3}[0-9c]{2})\s+(del)?`),
+		"mlab-sandbox": regexp.MustCompile(`\/machine\s+(mlab[1-4]\.[a-z]{3}[0-9]t)(\s+(del))?`),
+		"mlab-staging": regexp.MustCompile(`\/machine\s+(mlab[4]\.[a-z]{3}[0-9c]{2})(\s+(del))?`),
+		"mlab-oti":     regexp.MustCompile(`\/machine\s+(mlab[1-3]\.[a-z]{3}[0-9c]{2})(\s+(del))?`),
 	}
 
 	siteRegExps = map[string]*regexp.Regexp{
-		"mlab-sandbox": regexp.MustCompile(`\/site\s+([a-z]{3}[0-9]t)\s+(del)?`),
-		"mlab-staging": regexp.MustCompile(`\/site\s+([a-z]{3}[0-9c]{2})\s+(del)?`),
-		"mlab-oti":     regexp.MustCompile(`\/site\s+([a-z]{3}[0-9c]{2})\s+(del)?`),
+		"mlab-sandbox": regexp.MustCompile(`\/site\s+([a-z]{3}[0-9]t)(\s+(del))?`),
+		"mlab-staging": regexp.MustCompile(`\/site\s+([a-z]{3}[0-9c]{2})(\s+(del))?`),
+		"mlab-oti":     regexp.MustCompile(`\/site\s+([a-z]{3}[0-9c]{2})(\s+(del))?`),
 	}
 
 	// Prometheus metric for exposing any errors that the exporter encounters.
@@ -277,7 +277,7 @@ func parseMessage(msg string, issueNumber string, s *maintenanceState, project s
 	if len(siteMatches) > 0 {
 		for _, site := range siteMatches {
 			log.Printf("INFO: Flag found for site: %s", site[1])
-			if site[2] == "del" {
+			if site[3] == "del" {
 				updateState(s.Sites, site[1], metricSite, issueNumber, cLeaveMaintenance)
 				mods++
 				// Since site is leaving maintenance, remove all associated machine maintenances.
@@ -304,7 +304,7 @@ func parseMessage(msg string, issueNumber string, s *maintenanceState, project s
 		for _, machine := range machineMatches {
 			log.Printf("INFO: Flag found for machine: %s", machine[1])
 			label := machine[1] + ".measurement-lab.org"
-			if machine[2] == "del" {
+			if machine[3] == "del" {
 				updateState(s.Machines, label, metricMachine, issueNumber, cLeaveMaintenance)
 				mods++
 			} else {

--- a/gmx.go
+++ b/gmx.go
@@ -321,8 +321,8 @@ func parseMessage(msg string, issueNumber string, s *maintenanceState, project s
 // simply printing the name of the utility and returning a 200 status. This
 // could be used by, for example, kubernetes aliveness checks.
 func rootHandler(resp http.ResponseWriter, req *http.Request) {
-	fmt.Fprintf(resp, "GitHub Maintenance Exporter")
 	resp.WriteHeader(http.StatusOK)
+	fmt.Fprintf(resp, "GitHub Maintenance Exporter")
 	return
 }
 

--- a/gmx.go
+++ b/gmx.go
@@ -207,18 +207,18 @@ func removeIssue(stateMap map[string][]string, mapKey string, metricState *prome
 // number of modifications that were made to the machine and site maintenance
 // state.
 func closeIssue(issueNumber string, s *maintenanceState) int {
-	var total_mods = 0
+	var totalMods = 0
 	// Remove any sites from maintenance that were set by this issue.
 	for site, issues := range s.Sites {
 		issueIndex := stringInSlice(issueNumber, issues)
 		if issueIndex >= 0 {
 			mods := removeIssue(s.Sites, site, metricSite, issueNumber)
-			total_mods = total_mods + mods
+			totalMods = totalMods + mods
 			// Since site is leaving maintenance, remove all associated machine maintenances.
 			for _, num := range []string{"1", "2", "3", "4"} {
 				machine := "mlab" + num + "." + site + ".measurement-lab.org"
 				mods := removeIssue(s.Machines, machine, metricMachine, issueNumber)
-				total_mods = total_mods + mods
+				totalMods = totalMods + mods
 			}
 		}
 	}
@@ -228,11 +228,11 @@ func closeIssue(issueNumber string, s *maintenanceState) int {
 		issueIndex := stringInSlice(issueNumber, issues)
 		if issueIndex >= 0 {
 			mods := removeIssue(s.Machines, machine, metricMachine, issueNumber)
-			total_mods = total_mods + mods
+			totalMods = totalMods + mods
 		}
 	}
 
-	return total_mods
+	return totalMods
 }
 
 // updateState modifies the maintenance state of a machine or site in the

--- a/gmx.go
+++ b/gmx.go
@@ -52,15 +52,15 @@ var (
 	mux sync.Mutex
 
 	machineRegExps = map[string]*regexp.Regexp{
-		"mlab-sandbox": regexp.MustCompile(`\/machine\s+(mlab[1-4]\.[a-z]{3}[0-9]t)(\s+(del))?`),
-		"mlab-staging": regexp.MustCompile(`\/machine\s+(mlab[4]\.[a-z]{3}[0-9c]{2})(\s+(del))?`),
-		"mlab-oti":     regexp.MustCompile(`\/machine\s+(mlab[1-3]\.[a-z]{3}[0-9c]{2})(\s+(del))?`),
+		"mlab-sandbox": regexp.MustCompile(`\/machine\s+(mlab[1-4]\.[a-z]{3}[0-9]t)(\s+del)?`),
+		"mlab-staging": regexp.MustCompile(`\/machine\s+(mlab[4]\.[a-z]{3}[0-9c]{2})(\s+del)?`),
+		"mlab-oti":     regexp.MustCompile(`\/machine\s+(mlab[1-3]\.[a-z]{3}[0-9c]{2})(\s+del)?`),
 	}
 
 	siteRegExps = map[string]*regexp.Regexp{
-		"mlab-sandbox": regexp.MustCompile(`\/site\s+([a-z]{3}[0-9]t)(\s+(del))?`),
-		"mlab-staging": regexp.MustCompile(`\/site\s+([a-z]{3}[0-9c]{2})(\s+(del))?`),
-		"mlab-oti":     regexp.MustCompile(`\/site\s+([a-z]{3}[0-9c]{2})(\s+(del))?`),
+		"mlab-sandbox": regexp.MustCompile(`\/site\s+([a-z]{3}[0-9]t)(\s+del)?`),
+		"mlab-staging": regexp.MustCompile(`\/site\s+([a-z]{3}[0-9c]{2})(\s+del)?`),
+		"mlab-oti":     regexp.MustCompile(`\/site\s+([a-z]{3}[0-9c]{2})(\s+del)?`),
 	}
 
 	// Prometheus metric for exposing any errors that the exporter encounters.
@@ -277,7 +277,7 @@ func parseMessage(msg string, issueNumber string, s *maintenanceState, project s
 	if len(siteMatches) > 0 {
 		for _, site := range siteMatches {
 			log.Printf("INFO: Flag found for site: %s", site[1])
-			if site[3] == "del" {
+			if strings.TrimSpace(site[2]) == "del" {
 				updateState(s.Sites, site[1], metricSite, issueNumber, cLeaveMaintenance)
 				mods++
 				// Since site is leaving maintenance, remove all associated machine maintenances.
@@ -304,7 +304,7 @@ func parseMessage(msg string, issueNumber string, s *maintenanceState, project s
 		for _, machine := range machineMatches {
 			log.Printf("INFO: Flag found for machine: %s", machine[1])
 			label := machine[1] + ".measurement-lab.org"
-			if machine[3] == "del" {
+			if strings.TrimSpace(machine[2]) == "del" {
 				updateState(s.Machines, label, metricMachine, issueNumber, cLeaveMaintenance)
 				mods++
 			} else {

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -210,6 +210,22 @@ func TestReceiveHook(t *testing.T) {
 				}
 			`),
 		},
+		{
+			name:           "issue-comment-hook-flag-at-end-of-input",
+			secretKey:      githubSecret,
+			eventType:      "issue_comment",
+			expectedStatus: http.StatusOK,
+			payload: []byte(`
+				{
+					"action": "edited",
+					"issue": {
+						"number": 1,
+						"body": "Put into maintenance /machine mlab1.abc01",
+						"state": "open"
+					}
+				}
+			`),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Since GMX has been a thing, we have witnessed log messages like:

`http: multiple response.WriteHeader calls`

This PR _should_ eliminate those warnings. The cause was that `WriteHeader` was being called _after_ a regular `Write` to the response object. `WriteHeader` must be called first, else Go implicitly assumes a 200 response code.

Additionally, another bug is fixed in this PR in which sometimes sites/machines were not being put into maintenance if the maintenance flag was the very last string in the Github comment, with no trailing whitespace at all. In those cases, the regex was not picking up the flag, because it expected whitespace after the site/machine name.

Also, vscode warned me that `total_mods` was bad form in Golang, and that it should be `totalMods`, which this PR fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/25)
<!-- Reviewable:end -->
