### PR TITLE
Metrics moved to real namespace

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,45 @@
+// Package metrics provides metrics used throughout the program, and also exports the maintenance status of every site and machine.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// Error is a prometheus metric for exposing any errors that the exporter encounters.
+	//
+	// TODO: change to gmx_error_total in keeping with prometheus best practices
+	// as expressed by their linter.
+	Error = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gmx_error_count",
+			Help: "Count of errors.",
+		},
+		[]string{
+			"type",
+			"function",
+		},
+	)
+	// Machine is a prometheus metric for exposing machine maintenance status.
+	Machine = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gmx_machine_maintenance",
+			Help: "Whether a machine is in maitenance mode or not.",
+		},
+		[]string{
+			"machine",
+			"node",
+		},
+	)
+	// Site is a prometheus metric for exposing site maintenance status.
+	Site = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gmx_site_maintenance",
+			Help: "Whether a site is in maintenance mode or not.",
+		},
+		[]string{
+			"site",
+		},
+	)
+)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,15 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/m-lab/go/prometheusx/promtest"
+)
+
+func TestMetrics(t *testing.T) {
+	Error.WithLabelValues("x", "x").Inc()
+	Machine.WithLabelValues("x", "x").Inc()
+	Site.WithLabelValues("x").Inc()
+	// TODO: Pass in t once all metrics pass the linter.
+	promtest.LintMetrics(nil)
+}


### PR DESCRIPTION
the metrics were all named `metricError` and the like.  When variables and/or functions all share a common prefix or suffix, that's a hint that they should all go into their own package and the name of the package should be the common substring (or something close to it).

This is refactor 2 in a series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/27)
<!-- Reviewable:end -->
