### PR TITLE
Moves the state to its own package

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -347,11 +347,11 @@ func MustReadGithubSecret(filename string) []byte {
 func main() {
 	flag.Parse()
 
-	state = maintenancestate.New(*fStateFilePath)
-	err := state.Restore()
+	var err error
+	state, err = maintenancestate.New(*fStateFilePath)
 	if err != nil {
+		// TODO: Should this be a fatal error, or is this okay?
 		log.Printf("WARNING: Failed to open state file %s: %s", *fStateFilePath, err)
-		metrics.Error.WithLabelValues("openfile", "main").Add(1)
 	}
 
 	githubSecret = MustReadGithubSecret(*fGitHubSecretPath)

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -71,7 +71,7 @@ func TestRootHandler(t *testing.T) {
 }
 
 func TestReceiveHook(t *testing.T) {
-	state = maintenancestate.New("")
+	state, _ = maintenancestate.New("/does/not/exist/and/thats/okay")
 	githubSecret = []byte("goodsecret")
 
 	tests := []struct {
@@ -241,7 +241,8 @@ func TestCloseIssue(t *testing.T) {
 	defer os.Remove(fname)
 	rtx.Must(ioutil.WriteFile(fname, []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s := maintenancestate.New(fname)
+	s, err := maintenancestate.New(fname)
+	rtx.Must(err, "Could not read from tmpfile")
 
 	tests := []struct {
 		name              string
@@ -290,8 +291,8 @@ func TestParseMessage(t *testing.T) {
 	defer os.Remove(fname)
 	rtx.Must(ioutil.WriteFile(fname, []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s := maintenancestate.New(fname)
-	rtx.Must(s.Restore(), "Could not restore state")
+	s, err := maintenancestate.New(fname)
+	rtx.Must(err, "Could not restore state")
 
 	tests := []struct {
 		name         string

--- a/maintenancestate/state.go
+++ b/maintenancestate/state.go
@@ -1,0 +1,86 @@
+package maintenancestate
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+
+	"github.com/m-lab/github-maintenance-exporter/metrics"
+)
+
+type Action float64
+
+const (
+	EnterMaintenance Action = 1
+	LeaveMaintenance Action = 0
+)
+
+// MaintenanceState is a struct for storing both machine and site maintenance states.
+type MaintenanceState struct {
+	Machines, Sites map[string][]string
+	filename        string
+}
+
+func (s *MaintenanceState) Restore() error {
+	data, err := ioutil.ReadFile(s.filename)
+	if err != nil {
+		log.Printf("ERROR: Failed to read state data from %s: %s", s.filename, err)
+		metrics.Error.WithLabelValues("readfile", "restoreState").Inc()
+		return err
+	}
+
+	err = json.Unmarshal(data, &s)
+	if err != nil {
+		log.Printf("ERROR: Failed to unmarshal JSON: %s", err)
+		metrics.Error.WithLabelValues("unmarshaljson", "restoreState").Inc()
+		return err
+	}
+
+	// Restore machine maintenance state.
+	for machine := range s.Machines {
+		metrics.Machine.WithLabelValues(machine, machine).Set(float64(EnterMaintenance))
+	}
+
+	// Restore site maintenance state.
+	for site := range s.Sites {
+		metrics.Site.WithLabelValues(site).Set(float64(EnterMaintenance))
+	}
+
+	log.Printf("INFO: Successfully restored %s from disk.", s.filename)
+	return nil
+}
+
+// Write serializes the content of a maintenanceState object into JSON and
+// writes it to a file on disk.
+func (s *MaintenanceState) Write() error {
+	data, err := json.MarshalIndent(s, "", "    ")
+	if err != nil {
+		log.Printf("ERROR: Failed to marshal JSON: %s", err)
+		metrics.Error.WithLabelValues("marshaljson", "writeState").Add(1)
+		return err
+	}
+
+	err = ioutil.WriteFile(s.filename, data, 0664)
+	if err != nil {
+		log.Printf("ERROR: Failed to write state to %s: %s", s.filename, err)
+		metrics.Error.WithLabelValues("writefile", "writeState").Add(1)
+		return err
+	}
+
+	log.Printf("INFO: Successfully wrote state to %s.", s.filename)
+	return nil
+}
+
+func New(filename string) *MaintenanceState {
+	s := &MaintenanceState{
+		Machines: make(map[string][]string),
+		Sites:    make(map[string][]string),
+		filename: filename,
+	}
+	err := s.Restore()
+	if err != nil {
+		log.Printf("WARNING: Failed to open state file %s: %s", filename, err)
+		metrics.Error.WithLabelValues("openfile", "main").Add(1)
+	}
+	return s
+}

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -1,0 +1,58 @@
+package maintenancestate
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/m-lab/go/rtx"
+)
+
+// Sample maintenance state as written to disk in JSON format.
+var savedState = `
+	{
+		"Machines": {
+			"mlab1.abc01.measurement-lab.org": ["1"],
+			"mlab1.abc02.measurement-lab.org": ["8"],
+			"mlab2.abc02.measurement-lab.org": ["8"],
+			"mlab3.abc02.measurement-lab.org": ["8"],
+			"mlab4.abc02.measurement-lab.org": ["8"],
+			"mlab3.def01.measurement-lab.org": ["5"],
+			"mlab1.uvw03.measurement-lab.org": ["4", "11"],
+			"mlab2.uvw03.measurement-lab.org": ["4", "11"],
+			"mlab3.uvw03.measurement-lab.org": ["4", "11"],
+			"mlab4.uvw03.measurement-lab.org": ["4", "11"]
+		},
+		"Sites": {
+			"abc02": ["8"],
+			"uvw03": ["4", "11"]
+		}
+	}
+`
+
+func TestRestore(t *testing.T) {
+	f, err := ioutil.TempFile("", "TestRestore")
+	rtx.Must(err, "Could not create tempfile")
+	fname := f.Name()
+	defer os.Remove(fname)
+	rtx.Must(ioutil.WriteFile(fname, []byte(savedState), 0644), "Could not write state to tempfile")
+
+	s := New(fname)
+	rtx.Must(s.Restore(), "Could not restore state")
+	expectedMachines := 10
+	expectedSites := 2
+
+	if len(s.Machines) != expectedMachines {
+		t.Errorf("restoreState(): Expected %d restored machines; have %d.",
+			expectedMachines, len(s.Machines))
+	}
+
+	if len(s.Sites) != expectedSites {
+		t.Errorf("restoreState(): Expected %d restored sites; have %d.",
+			expectedSites, len(s.Sites))
+	}
+}
+
+func TestWrite(t *testing.T) {
+
+}

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -3,6 +3,8 @@ package maintenancestate
 import (
 	"io/ioutil"
 	"os"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/m-lab/go/rtx"
@@ -31,14 +33,13 @@ var savedState = `
 `
 
 func TestRestore(t *testing.T) {
-	f, err := ioutil.TempFile("", "TestRestore")
-	rtx.Must(err, "Could not create tempfile")
-	fname := f.Name()
-	defer os.Remove(fname)
-	rtx.Must(ioutil.WriteFile(fname, []byte(savedState), 0644), "Could not write state to tempfile")
+	dir, err := ioutil.TempDir("", "TestRestore")
+	rtx.Must(err, "Could not create tempdir")
+	defer os.RemoveAll(dir)
+	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s := New(fname)
-	rtx.Must(s.Restore(), "Could not restore state")
+	s, err := New(dir + "/state.json")
+	rtx.Must(err, "Could not restore state")
 	expectedMachines := 10
 	expectedSites := 2
 
@@ -51,8 +52,44 @@ func TestRestore(t *testing.T) {
 		t.Errorf("restoreState(): Expected %d restored sites; have %d.",
 			expectedSites, len(s.Sites))
 	}
+
+	// Now exercise the error cases
+	s2, err := New(dir + "/doesnotexist.json")
+	if s2 == nil || err == nil {
+		t.Error("Should have received a non-nil state and a non-nil error, but got:", s2, err)
+	}
+
+	rtx.Must(ioutil.WriteFile(dir+"/badcontents.json", []byte("This is not json"), 0644), "Could not write bad data for test")
+	s3, err := New(dir + "/badcontents.json")
+	if s3 == nil || err == nil {
+		t.Error("Should have received a non-nil state and a non-nil error, but got:", s3, err)
+	}
 }
 
 func TestWrite(t *testing.T) {
+	dir, err := ioutil.TempDir("", "TestWrite")
+	rtx.Must(err, "Could not create tempdir")
+	defer os.RemoveAll(dir)
+	rtx.Must(ioutil.WriteFile(dir+"/savedstate.json", []byte(savedState), 0644), "Could not write to file")
 
+	s1, err := New(dir + "/savedstate.json")
+	rtx.Must(err, "Could not restore state for s1")
+	s1.Machines["mlab1.abc01.measurement-lab.org"] = append(s1.Machines["mlab1.abc01.measurement-lab.org"], "2")
+	rtx.Must(s1.Write(), "Could not save state")
+
+	s2, err := New(dir + "/savedstate.json")
+	rtx.Must(err, "Could not restore state for s2")
+	if !reflect.DeepEqual(*s2, *s1) {
+		t.Error("The state was not the same after write/restore:", s1, s2)
+	}
+	if strings.Join(s2.Machines["mlab1.abc01.measurement-lab.org"], " ") != "1 2" {
+		t.Error("s2 was not different from the initial (not the saved and modified) input.", s2.Machines["mlab1.abc01.measurement-lab.org"])
+	}
+
+	// Now exercise the error cases
+	s2.filename = ""
+	err = s2.Write()
+	if err == nil {
+		t.Error("Should have had an error when writing s2 with an empty filename")
+	}
 }


### PR DESCRIPTION
First, we move the state saving and restoration to its own package.

We will likely move other things there later, but these initial functions all had "state" in the name, making the decision about where to put them be very easy.  This also is the first step in the elimination of the `state` global variable.  By the time we are done, the only globals should be in `main` and `metrics` and all other global vars should be absorbed into one component or another.

This is refactor 3 in a series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/28)
<!-- Reviewable:end -->
