### PR TITLE
Fixes a bug whereby production nodes were leaking into the staging GMX instance.

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -23,10 +23,11 @@ var (
 	fListenAddress    = flag.String("web.listen-address", ":9999", "Address to listen on for telemetry.")
 	fStateFilePath    = flag.String("storage.state-file", "/tmp/gmx-state", "Filesystem path for the state file.")
 	fGitHubSecretPath = flag.String("storage.github-secret", "", "Filesystem path of file containing the shared Github webhook secret.")
-	fProject          = flag.String("project", "mlab-oti", "GCP project where this instance is running.")
+	fProject          = flag.String("project", "", "GCP project where this instance is running.")
 
 	// Variables to aid in the testing of main()
 	mainCtx, mainCancel = context.WithCancel(context.Background())
+	validProjects       = []string{"mlab-sandbox", "mlab-staging", "mlab-oti"}
 	logFatal            = log.Fatal
 )
 
@@ -64,6 +65,18 @@ func MustReadGithubSecret(filename string) []byte {
 func main() {
 	defer mainCancel()
 	flag.Parse()
+
+	// Exit if an invalid/unknown project is passed.
+	var isValidProject = false
+	for _, project := range validProjects {
+		if project == *fProject {
+			isValidProject = true
+			break
+		}
+	}
+	if !isValidProject {
+		logFatal("Unknown project: ", *fProject)
+	}
 
 	// Read state and secrets off the disk.
 	state, err := maintenancestate.New(*fStateFilePath)

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -77,6 +77,20 @@ func TestGithubSecretFromEmptyFile(t *testing.T) {
 	MustReadGithubSecret(dir + "/secret")
 }
 
+func TestMainBadProject(t *testing.T) {
+	logFatal = func(...interface{}) { panic("testerror") }
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("Should have had a panic but did not")
+		}
+	}()
+
+	*fProject = "mlab-doesnotexist"
+
+	main()
+}
+
 func TestMainViaSmokeTest(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestMainViaSmokeTest")
 	rtx.Must(err, "Could not create tempdir")
@@ -94,6 +108,7 @@ func TestMainViaSmokeTest(t *testing.T) {
 	*fGitHubSecretPath = dir + "/secret"
 	*fStateFilePath = dir + "/state.json"
 	*fListenAddress = ":0"
+	*fProject = "mlab-sandbox"
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 	go func() {
 		time.Sleep(500 * time.Millisecond)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -111,7 +111,7 @@ func (h *handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		switch eventAction {
 		case "closed", "deleted":
 			log.Printf("INFO: Issue #%s was %s.", issueNumber, eventAction)
-			mods = h.state.CloseIssue(issueNumber)
+			mods = h.state.CloseIssue(issueNumber, h.project)
 		case "opened", "edited":
 			mods = h.parseMessage(event.Issue.GetBody(), issueNumber)
 		default:

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -48,9 +48,9 @@ func (h *handler) parseMessage(msg string, issueNumber string) int {
 		for _, site := range siteMatches {
 			log.Printf("INFO: Flag found for site: %s", site[1])
 			if strings.TrimSpace(site[2]) == "del" {
-				mods += h.state.UpdateSite(site[1], maintenancestate.LeaveMaintenance, issueNumber)
+				mods += h.state.UpdateSite(site[1], maintenancestate.LeaveMaintenance, issueNumber, h.project)
 			} else {
-				mods += h.state.UpdateSite(site[1], maintenancestate.EnterMaintenance, issueNumber)
+				mods += h.state.UpdateSite(site[1], maintenancestate.EnterMaintenance, issueNumber, h.project)
 			}
 		}
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -114,8 +114,7 @@ func TestReceiveHook(t *testing.T) {
 							"mlab1.abc01.measurement-lab.org": ["3"],
 							"mlab1.xyz01.measurement-lab.org": ["3"],
 							"mlab2.xyz01.measurement-lab.org": ["3"],
-							"mlab3.xyz01.measurement-lab.org": ["3"],
-							"mlab4.xyz01.measurement-lab.org": ["3"]
+							"mlab3.xyz01.measurement-lab.org": ["3"]
 						},
 						"Sites": {
 							"xyz01": ["3"]
@@ -343,21 +342,21 @@ func TestParseMessage(t *testing.T) {
 			msg:          `Putting /site abc01 and /site xyz02 into maintenance mode.`,
 			issue:        "99",
 			project:      `mlab-oti`,
-			expectedMods: 10,
+			expectedMods: 8,
 		},
 		{
 			name:         "add-1-sites-and-1-machine-to-maintenance",
 			msg:          `Putting /site abc01 and /machine mlab1.xyz02 into maintenance mode.`,
 			issue:        "99",
 			project:      `mlab-oti`,
-			expectedMods: 6,
+			expectedMods: 5,
 		},
 		{
 			name:         "remove-1-machine-and-1-site-from-maintenance",
 			msg:          `Removing /machine mlab2.xyz01 del and /site uvw03 del from maintenance.`,
 			issue:        "11",
 			project:      `mlab-oti`,
-			expectedMods: 6,
+			expectedMods: 5,
 		},
 		{
 			name:         "3-malformed-flags",

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -20,6 +20,7 @@ var savedState = `
 			"mlab3.abc02.measurement-lab.org": ["8"],
 			"mlab4.abc02.measurement-lab.org": ["8"],
 			"mlab3.def01.measurement-lab.org": ["5"],
+			"mlab4.def01.measurement-lab.org": ["20"],
 			"mlab1.uvw03.measurement-lab.org": ["4", "11"],
 			"mlab2.uvw03.measurement-lab.org": ["4", "11"],
 			"mlab3.uvw03.measurement-lab.org": ["4", "11"],
@@ -80,11 +81,11 @@ func TestUpdateSite(t *testing.T) {
 	if _, ok := s.state.Sites["def01"]; ok {
 		t.Error("Should not have def01 in sites.")
 	}
-	s.UpdateSite("def01", LeaveMaintenance, "20")
+	s.UpdateSite("def01", LeaveMaintenance, "20", "mlab-oti")
 	if _, ok := s.state.Sites["def01"]; ok {
 		t.Error("Should still not have def01 in sites.")
 	}
-	s.UpdateSite("def01", EnterMaintenance, "20")
+	s.UpdateSite("def01", EnterMaintenance, "20", "mlab-oti")
 	if len(s.state.Sites["def01"]) != 1 {
 		t.Error("Should have one issue for def01")
 	}
@@ -100,7 +101,7 @@ func TestUpdateSite(t *testing.T) {
 	if len(s.state.Machines["mlab4.def01.measurement-lab.org"]) != 1 {
 		t.Error("Should have one issue for mlab4.def01")
 	}
-	s.UpdateSite("def01", LeaveMaintenance, "20")
+	s.UpdateSite("def01", LeaveMaintenance, "20", "mlab-oti")
 	if _, ok := s.state.Sites["def01"]; ok {
 		t.Error("Should not have def01 in sites.")
 	}
@@ -113,8 +114,37 @@ func TestUpdateSite(t *testing.T) {
 	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 1 {
 		t.Error("Should have one issue for mlab3.def01")
 	}
-	if _, ok := s.state.Machines["mlab4.def01.measurement-lab.org"]; ok {
-		t.Error("Should have nothing for mlab4.def01")
+	s.UpdateSite("def01", EnterMaintenance, "25", "mlab-staging")
+	if len(s.state.Sites["def01"]) != 1 {
+		t.Error("Should have one issue for def01")
+	}
+	if _, ok := s.state.Machines["mlab1.def01.measurement-lab.org"]; ok {
+		t.Error("Should have nothing for mlab1.def01")
+	}
+	if _, ok := s.state.Machines["mlab2.def01.measurement-lab.org"]; ok {
+		t.Error("Should have nothing for mlab2.def01")
+	}
+	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 1 {
+		t.Error("Should have one issue for mlab3.def01")
+	}
+	if len(s.state.Machines["mlab4.def01.measurement-lab.org"]) != 2 {
+		t.Error("Should have two issues for mlab4.def01")
+	}
+	s.UpdateSite("def01", EnterMaintenance, "7", "mlab-sandbox")
+	if len(s.state.Sites["def01"]) != 2 {
+		t.Error("Should have two issues for def01")
+	}
+	if len(s.state.Machines["mlab1.def01.measurement-lab.org"]) != 1 {
+		t.Error("Should have one issue for mlab1.def01")
+	}
+	if len(s.state.Machines["mlab2.def01.measurement-lab.org"]) != 1 {
+		t.Error("Should have one issue for mlab2.def01")
+	}
+	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 2 {
+		t.Error("Should have two issues for mlab3.def01")
+	}
+	if len(s.state.Machines["mlab4.def01.measurement-lab.org"]) != 3 {
+		t.Error("Should have three issues for mlab4.def01")
 	}
 }
 
@@ -157,7 +187,7 @@ func TestCloseIssue(t *testing.T) {
 		rtx.Must(s.Restore(), "Could not restore state from tempfile")
 
 		totalEntitiesBefore := len(s.state.Machines) + len(s.state.Sites)
-		mods := s.CloseIssue(test.issue)
+		mods := s.CloseIssue(test.issue, "mlab-oti")
 		totalEntitiesAfter := len(s.state.Machines) + len(s.state.Sites)
 		closedMaintenance := totalEntitiesBefore - totalEntitiesAfter
 
@@ -181,7 +211,7 @@ func TestRestore(t *testing.T) {
 
 	s, err := New(dir + "/state.json")
 	rtx.Must(err, "Could not restore state")
-	expectedMachines := 10
+	expectedMachines := 11
 	expectedSites := 2
 
 	if len(s.state.Machines) != expectedMachines {


### PR DESCRIPTION
And vice versa, staging nodes were leaking into the production GMX Prometheus metrics.

This is caused by the fact that, currently, `maintenancestate.UpdateSite()` categorically adds/removes mlab[1-4] from maintenance, no matter the project. In mlab-staging, for example, it should only be adding/removing mlab4s from GMX. This bug is only affecting Prometheus metrics, as the correct logic already exists for updating GMX state in both memory and disk.  The principal negative effect of this bug is that production nodes are ending up in the staging mlab-ns datastore, causing the staging mlab-ns instance to return production nodes. This wasn't happening in production, because in production there is an explicit check to be sure that node is mlab[1-3] before adding it to the datastore (or memcache).

This PR attempts to resolve Issue #33, which documents this bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/34)
<!-- Reviewable:end -->
