### PR TITLE
Makes GMX compatible with v2 node names.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 as build
+FROM golang:1.14 as build
 WORKDIR /go/src/github.com/m-lab/github-maintenance-exporter
 ADD . ./
 RUN CGO_ENABLED=0 go get -v github.com/m-lab/github-maintenance-exporter

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -17,9 +17,9 @@ import (
 
 var (
 	machineRegExps = map[string]*regexp.Regexp{
-		"mlab-sandbox": regexp.MustCompile(`\/machine\s+(mlab[1-4]\.[a-z]{3}[0-9]t)(\s+del)?`),
-		"mlab-staging": regexp.MustCompile(`\/machine\s+(mlab[4]\.[a-z]{3}[0-9c]{2})(\s+del)?`),
-		"mlab-oti":     regexp.MustCompile(`\/machine\s+(mlab[1-3]\.[a-z]{3}[0-9c]{2})(\s+del)?`),
+		"mlab-sandbox": regexp.MustCompile(`\/machine\s+(mlab[1-4][.-][a-z]{3}[0-9]t)(\s+del)?`),
+		"mlab-staging": regexp.MustCompile(`\/machine\s+(mlab[4][.-][a-z]{3}[0-9c]{2})(\s+del)?`),
+		"mlab-oti":     regexp.MustCompile(`\/machine\s+(mlab[1-3][.-][a-z]{3}[0-9c]{2})(\s+del)?`),
 	}
 
 	siteRegExps = map[string]*regexp.Regexp{
@@ -59,12 +59,12 @@ func (h *handler) parseMessage(msg string, issueNumber string) int {
 	if len(machineMatches) > 0 {
 		for _, machine := range machineMatches {
 			log.Printf("INFO: Flag found for machine: %s", machine[1])
-			label := machine[1] + ".measurement-lab.org"
+			label := strings.Replace(machine[1], ".", "-", 1)
 			if strings.TrimSpace(machine[2]) == "del" {
-				h.state.UpdateMachine(label, maintenancestate.LeaveMaintenance, issueNumber)
+				h.state.UpdateMachine(label, maintenancestate.LeaveMaintenance, issueNumber, h.project)
 				mods++
 			} else {
-				h.state.UpdateMachine(label, maintenancestate.EnterMaintenance, issueNumber)
+				h.state.UpdateMachine(label, maintenancestate.EnterMaintenance, issueNumber, h.project)
 				mods++
 			}
 		}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -19,16 +19,16 @@ import (
 var savedState = `
 	{
 		"Machines": {
-			"mlab1.abc01.measurement-lab.org": ["1"],
-			"mlab1.abc02.measurement-lab.org": ["8"],
-			"mlab2.abc02.measurement-lab.org": ["8"],
-			"mlab3.abc02.measurement-lab.org": ["8"],
-			"mlab4.abc02.measurement-lab.org": ["8"],
-			"mlab3.def01.measurement-lab.org": ["5"],
-			"mlab1.uvw03.measurement-lab.org": ["4", "11"],
-			"mlab2.uvw03.measurement-lab.org": ["4", "11"],
-			"mlab3.uvw03.measurement-lab.org": ["4", "11"],
-			"mlab4.uvw03.measurement-lab.org": ["4", "11"]
+			"mlab1-abc01": ["1"],
+			"mlab1-abc02": ["8"],
+			"mlab2-abc02": ["8"],
+			"mlab3-abc02": ["8"],
+			"mlab4-abc02": ["8"],
+			"mlab3-def01": ["5"],
+			"mlab1-uvw03": ["4", "11"],
+			"mlab2-uvw03": ["4", "11"],
+			"mlab3-uvw03": ["4", "11"],
+			"mlab4-uvw03": ["4", "11"]
 		},
 		"Sites": {
 			"abc02": ["8"],
@@ -111,10 +111,10 @@ func TestReceiveHook(t *testing.T) {
 			expectedState: `
 					{
 						"Machines": {
-							"mlab1.abc01.measurement-lab.org": ["3"],
-							"mlab1.xyz01.measurement-lab.org": ["3"],
-							"mlab2.xyz01.measurement-lab.org": ["3"],
-							"mlab3.xyz01.measurement-lab.org": ["3"]
+							"mlab1-abc01": ["3"],
+							"mlab1-xyz01": ["3"],
+							"mlab2-xyz01": ["3"],
+							"mlab3-xyz01": ["3"]
 						},
 						"Sites": {
 							"xyz01": ["3"]
@@ -139,11 +139,11 @@ func TestReceiveHook(t *testing.T) {
 			initialState: `
 				{
 					"Machines": {
-						"mlab1.abc01.measurement-lab.org": ["3"],
-						"mlab1.xyz01.measurement-lab.org": ["3"],
-						"mlab2.xyz01.measurement-lab.org": ["3", "5"],
-						"mlab3.xyz01.measurement-lab.org": ["3"],
-						"mlab4.xyz01.measurement-lab.org": ["3"]
+						"mlab1-abc01": ["3"],
+						"mlab1-xyz01": ["3"],
+						"mlab2-xyz01": ["3", "5"],
+						"mlab3-xyz01": ["3"],
+						"mlab4-xyz01": ["3"]
 					},
 					"Sites": {
 						"xyz01": ["3"]
@@ -153,7 +153,7 @@ func TestReceiveHook(t *testing.T) {
 			expectedState: `
 				{
 					"Machines": {
-						"mlab2.xyz01.measurement-lab.org": ["5"]
+						"mlab2-xyz01": ["5"]
 					},
 					"Sites": {
 					}
@@ -218,15 +218,15 @@ func TestReceiveHook(t *testing.T) {
 			initialState: `
 				{
 					"Machines": {
-						"mlab1.abc01.measurement-lab.org": ["1"],
-						"mlab2.xyz01.measurement-lab.org": ["3", "5"]
+						"mlab1-abc01": ["1"],
+						"mlab2-xyz01": ["3", "5"]
 					}
 				}
 				`,
 			expectedState: `
 				{
 					"Machines": {
-						"mlab2.xyz01.measurement-lab.org": ["3", "5"]
+						"mlab2-xyz01": ["3", "5"]
 					}
 				}
 			`,
@@ -244,14 +244,14 @@ func TestReceiveHook(t *testing.T) {
 							"state": "open"
 						},
 						"comment": {
-							"body": "Put into maintenance /machine mlab1.abc01"
+							"body": "Put into maintenance /machine mlab1-abc01"
 						}
 					}
 				`,
 			expectedState: `
 				{
 					"Machines": {
-						"mlab1.abc01.measurement-lab.org": ["1"]
+						"mlab1-abc01": ["1"]
 					}
 				}
 				`,

--- a/maintenancestate/state.go
+++ b/maintenancestate/state.go
@@ -53,22 +53,6 @@ func stringInSlice(s string, list []string) int {
 	return -1
 }
 
-// createNodeLabel generate an approprate v1 or v2 node name label for a Prometheus metric.
-// TODO(kinkade): remove this once we are fully migrated to v2 names.
-func createNodeLabel(shortNode string, project string, version string) string {
-	var label string
-
-	// Construct and add labels for v1 and v2 names.
-	// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
-	if version == "v1" {
-		label = strings.Replace(shortNode, "-", ".", 1) + ".measurement-lab.org"
-	} else {
-		label = strings.Replace(shortNode, ".", "-", 1) + "." + project + ".measurement-lab.org"
-	}
-
-	return label
-}
-
 // Removes a single issue from a site/machine. If the issue was the last one
 // associated with the site/machine, it will also remove the site/machine
 // from maintenance.
@@ -84,18 +68,7 @@ func removeIssue(stateMap map[string][]string, mapKey string, metricState *prome
 		mapElement = mapElement[:len(mapElement)-1]
 		if len(mapElement) == 0 {
 			delete(stateMap, mapKey)
-			// If this is a machine state, then we need to pass mapKey twice, once for the
-			// "machine" label and once for the "node" label.
-			if strings.HasPrefix(mapKey, "mlab") {
-				// Construct and add labels for v1 and v2 names.
-				// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
-				machineLabelV1 := createNodeLabel(mapKey, project, "v1")
-				machineLabelV2 := createNodeLabel(mapKey, project, "v2")
-				metricState.WithLabelValues(machineLabelV1, machineLabelV1).Set(0)
-				metricState.WithLabelValues(machineLabelV2, machineLabelV2).Set(0)
-			} else {
-				metricState.WithLabelValues(mapKey).Set(0)
-			}
+			updateMetrics(mapKey, project, LeaveMaintenance, metricState)
 		} else {
 			stateMap[mapKey] = mapElement
 		}
@@ -103,6 +76,22 @@ func removeIssue(stateMap map[string][]string, mapKey string, metricState *prome
 		mods++
 	}
 	return mods
+}
+
+// updateMetrics updates the Prometheus metrics for machine or site.
+func updateMetrics(mapKey string, project string, action Action, metricState *prometheus.GaugeVec) {
+	// If this is a machine state, then we need to pass mapKey twice, once for the
+	// "machine" label and once for the "node" label.
+	if strings.HasPrefix(mapKey, "mlab") {
+		// Construct and add labels for v1 and v2 names.
+		// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
+		machineLabelV1 := strings.Replace(mapKey, "-", ".", 1) + ".measurement-lab.org"
+		machineLabelV2 := strings.Replace(mapKey, ".", "-", 1) + "." + project + ".measurement-lab.org"
+		metricState.WithLabelValues(machineLabelV1, machineLabelV1).Set(action.StatusValue())
+		metricState.WithLabelValues(machineLabelV2, machineLabelV2).Set(action.StatusValue())
+	} else {
+		metricState.WithLabelValues(mapKey).Set(action.StatusValue())
+	}
 }
 
 // updateState modifies the maintenance state of a machine or site in the
@@ -120,18 +109,7 @@ func updateState(stateMap map[string][]string, mapKey string, metricState *prome
 			return 0
 		}
 		stateMap[mapKey] = append(stateMap[mapKey], issueNumber)
-		// If this is a machine state, then we need to pass mapKey twice, once for the
-		// "machine" label and once for the "node" label.
-		if strings.HasPrefix(mapKey, "mlab") {
-			// Construct and add labels for v1 and v2 names.
-			// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
-			machineLabelV1 := createNodeLabel(mapKey, project, "v1")
-			machineLabelV2 := createNodeLabel(mapKey, project, "v2")
-			metricState.WithLabelValues(machineLabelV1, machineLabelV1).Set(action.StatusValue())
-			metricState.WithLabelValues(machineLabelV2, machineLabelV2).Set(action.StatusValue())
-		} else {
-			metricState.WithLabelValues(mapKey).Set(action.StatusValue())
-		}
+		updateMetrics(mapKey, project, action, metricState)
 		log.Printf("INFO: %s was added to maintenance for issue #%s", mapKey, issueNumber)
 		return 1
 	default:

--- a/maintenancestate/state.go
+++ b/maintenancestate/state.go
@@ -53,6 +53,22 @@ func stringInSlice(s string, list []string) int {
 	return -1
 }
 
+// createNodeLabel generate an approprate v1 or v2 node name label for a Prometheus metric.
+// TODO(kinkade): remove this once we are fully migrated to v2 names.
+func createNodeLabel(shortNode string, project string, version string) string {
+	var label string
+
+	// Construct and add labels for v1 and v2 names.
+	// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
+	if version == "v1" {
+		label = strings.Replace(shortNode, "-", ".", 1) + ".measurement-lab.org"
+	} else {
+		label = strings.Replace(shortNode, ".", "-", 1) + "." + project + ".measurement-lab.org"
+	}
+
+	return label
+}
+
 // Removes a single issue from a site/machine. If the issue was the last one
 // associated with the site/machine, it will also remove the site/machine
 // from maintenance.
@@ -73,8 +89,8 @@ func removeIssue(stateMap map[string][]string, mapKey string, metricState *prome
 			if strings.HasPrefix(mapKey, "mlab") {
 				// Construct and add labels for v1 and v2 names.
 				// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
-				machineLabelV1 := strings.Replace(mapKey, "-", ".", 1) + ".measurement-lab.org"
-				machineLabelV2 := mapKey + "." + project + ".measurement-lab.org"
+				machineLabelV1 := createNodeLabel(mapKey, project, "v1")
+				machineLabelV2 := createNodeLabel(mapKey, project, "v2")
 				metricState.WithLabelValues(machineLabelV1, machineLabelV1).Set(0)
 				metricState.WithLabelValues(machineLabelV2, machineLabelV2).Set(0)
 			} else {
@@ -109,8 +125,8 @@ func updateState(stateMap map[string][]string, mapKey string, metricState *prome
 		if strings.HasPrefix(mapKey, "mlab") {
 			// Construct and add labels for v1 and v2 names.
 			// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
-			machineLabelV1 := strings.Replace(mapKey, "-", ".", 1) + ".measurement-lab.org"
-			machineLabelV2 := mapKey + "." + project + ".measurement-lab.org"
+			machineLabelV1 := createNodeLabel(mapKey, project, "v1")
+			machineLabelV2 := createNodeLabel(mapKey, project, "v2")
 			metricState.WithLabelValues(machineLabelV1, machineLabelV1).Set(action.StatusValue())
 			metricState.WithLabelValues(machineLabelV2, machineLabelV2).Set(action.StatusValue())
 		} else {

--- a/maintenancestate/state.go
+++ b/maintenancestate/state.go
@@ -87,7 +87,7 @@ func removeIssue(stateMap map[string][]string, mapKey string, metricState *prome
 // updateState modifies the maintenance state of a machine or site in the
 // in-memory map as well as updating the Prometheus metric.
 func updateState(stateMap map[string][]string, mapKey string, metricState *prometheus.GaugeVec,
-	issueNumber string, action Action) int {
+	issueNumber string, action Action, project string) int {
 	switch action {
 	case LeaveMaintenance:
 		return removeIssue(stateMap, mapKey, metricState, issueNumber)
@@ -102,7 +102,12 @@ func updateState(stateMap map[string][]string, mapKey string, metricState *prome
 		// If this is a machine state, then we need to pass mapKey twice, once for the
 		// "machine" label and once for the "node" label.
 		if strings.HasPrefix(mapKey, "mlab") {
-			metricState.WithLabelValues(mapKey, mapKey).Set(action.StatusValue())
+			// Construct and add labels for v1 and v2 names.
+			// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
+			machineLabelV1 := strings.Replace(mapKey, "-", ".", 1) + ".measurement-lab.org"
+			machineLabelV2 := mapKey + "." + project + ".measurement-lab.org"
+			metricState.WithLabelValues(machineLabelV1, machineLabelV1).Set(action.StatusValue())
+			metricState.WithLabelValues(machineLabelV2, machineLabelV2).Set(action.StatusValue())
 		} else {
 			metricState.WithLabelValues(mapKey).Set(action.StatusValue())
 		}
@@ -162,14 +167,14 @@ func (ms *MaintenanceState) Write() error {
 }
 
 // UpdateMachine causes a single machine to enter or exit maintenance mode.
-func (ms *MaintenanceState) UpdateMachine(machine string, action Action, issue string) int {
-	return updateState(ms.state.Machines, machine, metrics.Machine, issue, action)
+func (ms *MaintenanceState) UpdateMachine(machine string, action Action, issue string, project string) int {
+	return updateState(ms.state.Machines, machine, metrics.Machine, issue, action, project)
 }
 
 // UpdateSite causes a whole site to enter or exit maintenance mode.
 func (ms *MaintenanceState) UpdateSite(site string, action Action, issue string, project string) int {
 	var nodes []string
-	mods := updateState(ms.state.Sites, site, metrics.Site, issue, action)
+	mods := updateState(ms.state.Sites, site, metrics.Site, issue, action, project)
 	// If a site is entering or leaving maintenance, automatically add/remove
 	// the project-appropriate nodes to/from maintenance.
 	switch project {
@@ -181,8 +186,8 @@ func (ms *MaintenanceState) UpdateSite(site string, action Action, issue string,
 		nodes = []string{"1", "2", "3"}
 	}
 	for _, num := range nodes {
-		machine := "mlab" + num + "." + site + ".measurement-lab.org"
-		mods += ms.UpdateMachine(machine, action, issue)
+		machine := "mlab" + num + "-" + site
+		mods += ms.UpdateMachine(machine, action, issue, project)
 	}
 	log.Println("Mods is", mods)
 	return mods
@@ -201,7 +206,7 @@ func (ms *MaintenanceState) CloseIssue(issue string, project string) int {
 
 	// Remove any machines from maintenance that were set by this issue.
 	for machine := range ms.state.Machines {
-		totalMods += ms.UpdateMachine(machine, LeaveMaintenance, issue)
+		totalMods += ms.UpdateMachine(machine, LeaveMaintenance, issue, project)
 	}
 
 	return totalMods

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -69,6 +69,60 @@ func TestUpdateMachine(t *testing.T) {
 	}
 }
 
+func TestCreateNodeLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		shortNode string
+		version   string
+		project   string
+		expected  string
+	}{
+		{
+			name:      "create-v1-label-from-dotted-name",
+			shortNode: "mlab4.abc02",
+			version:   "v1",
+			project:   "mlab-staging",
+			expected:  "mlab4.abc02.measurement-lab.org",
+		},
+		{
+			name:      "create-v1-label-from-flat-name",
+			shortNode: "mlab1-abc02",
+			version:   "v1",
+			project:   "mlab-oti",
+			expected:  "mlab1.abc02.measurement-lab.org",
+		},
+		{
+			name:      "create-v2-label-from-dotted-name",
+			shortNode: "mlab1.abc02",
+			version:   "v2",
+			project:   "mlab-oti",
+			expected:  "mlab1-abc02.mlab-oti.measurement-lab.org",
+		},
+		{
+			name:      "create-v2-label-from-flat-name",
+			shortNode: "mlab1-abc0t",
+			version:   "v2",
+			project:   "mlab-sandbox",
+			expected:  "mlab1-abc0t.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name:      "create-label-with-no-version",
+			shortNode: "mlab1.abc02",
+			version:   "",
+			project:   "mlab-oti",
+			expected:  "mlab1-abc02.mlab-oti.measurement-lab.org",
+		},
+	}
+
+	for _, test := range tests {
+		actual := createNodeLabel(test.shortNode, test.project, test.version)
+
+		if actual != test.expected {
+			t.Errorf("createNodeLabel(): Expected label %s; got %s", test.expected, actual)
+		}
+	}
+}
+
 func TestUpdateSite(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestUpdateSite")
 	rtx.Must(err, "Could not create tempdir")

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -69,60 +69,6 @@ func TestUpdateMachine(t *testing.T) {
 	}
 }
 
-func TestCreateNodeLabel(t *testing.T) {
-	tests := []struct {
-		name      string
-		shortNode string
-		version   string
-		project   string
-		expected  string
-	}{
-		{
-			name:      "create-v1-label-from-dotted-name",
-			shortNode: "mlab4.abc02",
-			version:   "v1",
-			project:   "mlab-staging",
-			expected:  "mlab4.abc02.measurement-lab.org",
-		},
-		{
-			name:      "create-v1-label-from-flat-name",
-			shortNode: "mlab1-abc02",
-			version:   "v1",
-			project:   "mlab-oti",
-			expected:  "mlab1.abc02.measurement-lab.org",
-		},
-		{
-			name:      "create-v2-label-from-dotted-name",
-			shortNode: "mlab1.abc02",
-			version:   "v2",
-			project:   "mlab-oti",
-			expected:  "mlab1-abc02.mlab-oti.measurement-lab.org",
-		},
-		{
-			name:      "create-v2-label-from-flat-name",
-			shortNode: "mlab1-abc0t",
-			version:   "v2",
-			project:   "mlab-sandbox",
-			expected:  "mlab1-abc0t.mlab-sandbox.measurement-lab.org",
-		},
-		{
-			name:      "create-label-with-no-version",
-			shortNode: "mlab1.abc02",
-			version:   "",
-			project:   "mlab-oti",
-			expected:  "mlab1-abc02.mlab-oti.measurement-lab.org",
-		},
-	}
-
-	for _, test := range tests {
-		actual := createNodeLabel(test.shortNode, test.project, test.version)
-
-		if actual != test.expected {
-			t.Errorf("createNodeLabel(): Expected label %s; got %s", test.expected, actual)
-		}
-	}
-}
-
 func TestUpdateSite(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestUpdateSite")
 	rtx.Must(err, "Could not create tempdir")

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -14,17 +14,17 @@ import (
 var savedState = `
 	{
 		"Machines": {
-			"mlab1.abc01.measurement-lab.org": ["1"],
-			"mlab1.abc02.measurement-lab.org": ["8"],
-			"mlab2.abc02.measurement-lab.org": ["8"],
-			"mlab3.abc02.measurement-lab.org": ["8"],
-			"mlab4.abc02.measurement-lab.org": ["8"],
-			"mlab3.def01.measurement-lab.org": ["5"],
-			"mlab4.def01.measurement-lab.org": ["20"],
-			"mlab1.uvw03.measurement-lab.org": ["4", "11"],
-			"mlab2.uvw03.measurement-lab.org": ["4", "11"],
-			"mlab3.uvw03.measurement-lab.org": ["4", "11"],
-			"mlab4.uvw03.measurement-lab.org": ["4", "11"]
+			"mlab1-abc01": ["1"],
+			"mlab1-abc02": ["8"],
+			"mlab2-abc02": ["8"],
+			"mlab3-abc02": ["8"],
+			"mlab4-abc02": ["8"],
+			"mlab3-def01": ["5"],
+			"mlab4-def01": ["20"],
+			"mlab1-uvw03": ["4", "11"],
+			"mlab2-uvw03": ["4", "11"],
+			"mlab3-uvw03": ["4", "11"],
+			"mlab4-uvw03": ["4", "11"]
 		},
 		"Sites": {
 			"abc02": ["8"],
@@ -52,20 +52,20 @@ func TestUpdateMachine(t *testing.T) {
 	s, err := New(dir + "/state.json")
 	rtx.Must(err, "Could not read from tmpfile")
 
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", EnterMaintenance, "13", "mlab-oti")
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", EnterMaintenance, "13", "mlab-oti")
-	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 2 {
-		t.Error("Should have two items in", s.state.Machines["mlab3.def01.measurement-lab.org"])
+	s.UpdateMachine("mlab3-def01", EnterMaintenance, "13", "mlab-oti")
+	s.UpdateMachine("mlab3-def01", EnterMaintenance, "13", "mlab-oti")
+	if len(s.state.Machines["mlab3-def01"]) != 2 {
+		t.Error("Should have two items in", s.state.Machines["mlab3-def01"])
 	}
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "5", "mlab-oti")
-	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 1 {
-		t.Error("Should have one item in", s.state.Machines["mlab3.def01.measurement-lab.org"])
+	s.UpdateMachine("mlab3-def01", LeaveMaintenance, "5", "mlab-oti")
+	if len(s.state.Machines["mlab3-def01"]) != 1 {
+		t.Error("Should have one item in", s.state.Machines["mlab3-def01"])
 	}
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "5", "mlab-oti")
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "13", "mlab-oti")
+	s.UpdateMachine("mlab3-def01", LeaveMaintenance, "5", "mlab-oti")
+	s.UpdateMachine("mlab3-def01", LeaveMaintenance, "13", "mlab-oti")
 
-	if _, ok := s.state.Machines["mlab3.def01.measurement-lab.org"]; ok {
-		t.Errorf("%q was supposed to be deleted from %+v", "mlab3.def01.measurement-lab.org", s)
+	if _, ok := s.state.Machines["mlab3-def01"]; ok {
+		t.Errorf("%q was supposed to be deleted from %+v", "mlab3-def01", s)
 	}
 }
 
@@ -89,62 +89,62 @@ func TestUpdateSite(t *testing.T) {
 	if len(s.state.Sites["def01"]) != 1 {
 		t.Error("Should have one issue for def01")
 	}
-	if len(s.state.Machines["mlab1.def01.measurement-lab.org"]) != 1 {
-		t.Error("Should have one issue for mlab1.def01")
+	if len(s.state.Machines["mlab1-def01"]) != 1 {
+		t.Error("Should have one issue for mlab1-def01")
 	}
-	if len(s.state.Machines["mlab2.def01.measurement-lab.org"]) != 1 {
-		t.Error("Should have one issue for mlab2.def01")
+	if len(s.state.Machines["mlab2-def01"]) != 1 {
+		t.Error("Should have one issue for mlab2-def01")
 	}
-	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 2 {
-		t.Error("Should have two issues for mlab3.def01")
+	if len(s.state.Machines["mlab3-def01"]) != 2 {
+		t.Error("Should have two issues for mlab3-def01")
 	}
-	if len(s.state.Machines["mlab4.def01.measurement-lab.org"]) != 1 {
-		t.Error("Should have one issue for mlab4.def01")
+	if len(s.state.Machines["mlab4-def01"]) != 1 {
+		t.Error("Should have one issue for mlab4-def01")
 	}
 	s.UpdateSite("def01", LeaveMaintenance, "20", "mlab-oti")
 	if _, ok := s.state.Sites["def01"]; ok {
 		t.Error("Should not have def01 in sites.")
 	}
-	if _, ok := s.state.Machines["mlab1.def01.measurement-lab.org"]; ok {
-		t.Error("Should have nothing for mlab1.def01")
+	if _, ok := s.state.Machines["mlab1-def01"]; ok {
+		t.Error("Should have nothing for mlab1-def01")
 	}
-	if _, ok := s.state.Machines["mlab2.def01.measurement-lab.org"]; ok {
-		t.Error("Should have nothing for mlab2.def01")
+	if _, ok := s.state.Machines["mlab2-def01"]; ok {
+		t.Error("Should have nothing for mlab2-def01")
 	}
-	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 1 {
-		t.Error("Should have one issue for mlab3.def01")
+	if len(s.state.Machines["mlab3-def01"]) != 1 {
+		t.Error("Should have one issue for mlab3-def01")
 	}
 	s.UpdateSite("def01", EnterMaintenance, "25", "mlab-staging")
 	if len(s.state.Sites["def01"]) != 1 {
 		t.Error("Should have one issue for def01")
 	}
-	if _, ok := s.state.Machines["mlab1.def01.measurement-lab.org"]; ok {
-		t.Error("Should have nothing for mlab1.def01")
+	if _, ok := s.state.Machines["mlab1-def01"]; ok {
+		t.Error("Should have nothing for mlab1-def01")
 	}
-	if _, ok := s.state.Machines["mlab2.def01.measurement-lab.org"]; ok {
-		t.Error("Should have nothing for mlab2.def01")
+	if _, ok := s.state.Machines["mlab2-def01"]; ok {
+		t.Error("Should have nothing for mlab2-def01")
 	}
-	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 1 {
-		t.Error("Should have one issue for mlab3.def01")
+	if len(s.state.Machines["mlab3-def01"]) != 1 {
+		t.Error("Should have one issue for mlab3-def01")
 	}
-	if len(s.state.Machines["mlab4.def01.measurement-lab.org"]) != 2 {
-		t.Error("Should have two issues for mlab4.def01")
+	if len(s.state.Machines["mlab4-def01"]) != 2 {
+		t.Error("Should have two issues for mlab4-def01")
 	}
 	s.UpdateSite("def01", EnterMaintenance, "7", "mlab-sandbox")
 	if len(s.state.Sites["def01"]) != 2 {
 		t.Error("Should have two issues for def01")
 	}
-	if len(s.state.Machines["mlab1.def01.measurement-lab.org"]) != 1 {
-		t.Error("Should have one issue for mlab1.def01")
+	if len(s.state.Machines["mlab1-def01"]) != 1 {
+		t.Error("Should have one issue for mlab1-def01")
 	}
-	if len(s.state.Machines["mlab2.def01.measurement-lab.org"]) != 1 {
-		t.Error("Should have one issue for mlab2.def01")
+	if len(s.state.Machines["mlab2-def01"]) != 1 {
+		t.Error("Should have one issue for mlab2-def01")
 	}
-	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 2 {
-		t.Error("Should have two issues for mlab3.def01")
+	if len(s.state.Machines["mlab3-def01"]) != 2 {
+		t.Error("Should have two issues for mlab3-def01")
 	}
-	if len(s.state.Machines["mlab4.def01.measurement-lab.org"]) != 3 {
-		t.Error("Should have three issues for mlab4.def01")
+	if len(s.state.Machines["mlab4-def01"]) != 3 {
+		t.Error("Should have three issues for mlab4-def01")
 	}
 }
 
@@ -245,7 +245,7 @@ func TestWrite(t *testing.T) {
 
 	s1, err := New(dir + "/savedstate.json")
 	rtx.Must(err, "Could not restore state for s1")
-	s1.UpdateMachine("mlab1.abc01.measurement-lab.org", EnterMaintenance, "2", "mlab-oti")
+	s1.UpdateMachine("mlab1-abc01", EnterMaintenance, "2", "mlab-oti")
 	rtx.Must(s1.Write(), "Could not save state")
 
 	s2, err := New(dir + "/savedstate.json")
@@ -253,8 +253,8 @@ func TestWrite(t *testing.T) {
 	if !reflect.DeepEqual(*s2, *s1) {
 		t.Error("The state was not the same after write/restore:", s1, s2)
 	}
-	if strings.Join(s2.state.Machines["mlab1.abc01.measurement-lab.org"], " ") != "1 2" {
-		t.Error("s2 was not different from the initial (not the saved and modified) input.", s2.state.Machines["mlab1.abc01.measurement-lab.org"])
+	if strings.Join(s2.state.Machines["mlab1-abc01"], " ") != "1 2" {
+		t.Error("s2 was not different from the initial (not the saved and modified) input.", s2.state.Machines["mlab1-abc01"])
 	}
 
 	// Now exercise the error cases

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -40,7 +40,7 @@ func TestActionStatus(t *testing.T) {
 }
 
 func TestUpdateStateWithBadValue(t *testing.T) {
-	updateState(nil, "", nil, "", -1) // The -1 should not be a legal action.
+	updateState(nil, "", nil, "", -1, "no-project") // The -1 should not be a legal action.
 }
 
 func TestUpdateMachine(t *testing.T) {
@@ -52,17 +52,17 @@ func TestUpdateMachine(t *testing.T) {
 	s, err := New(dir + "/state.json")
 	rtx.Must(err, "Could not read from tmpfile")
 
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", EnterMaintenance, "13")
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", EnterMaintenance, "13")
+	s.UpdateMachine("mlab3.def01.measurement-lab.org", EnterMaintenance, "13", "mlab-oti")
+	s.UpdateMachine("mlab3.def01.measurement-lab.org", EnterMaintenance, "13", "mlab-oti")
 	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 2 {
 		t.Error("Should have two items in", s.state.Machines["mlab3.def01.measurement-lab.org"])
 	}
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "5")
+	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "5", "mlab-oti")
 	if len(s.state.Machines["mlab3.def01.measurement-lab.org"]) != 1 {
 		t.Error("Should have one item in", s.state.Machines["mlab3.def01.measurement-lab.org"])
 	}
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "5")
-	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "13")
+	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "5", "mlab-oti")
+	s.UpdateMachine("mlab3.def01.measurement-lab.org", LeaveMaintenance, "13", "mlab-oti")
 
 	if _, ok := s.state.Machines["mlab3.def01.measurement-lab.org"]; ok {
 		t.Errorf("%q was supposed to be deleted from %+v", "mlab3.def01.measurement-lab.org", s)
@@ -245,7 +245,7 @@ func TestWrite(t *testing.T) {
 
 	s1, err := New(dir + "/savedstate.json")
 	rtx.Must(err, "Could not restore state for s1")
-	s1.UpdateMachine("mlab1.abc01.measurement-lab.org", EnterMaintenance, "2")
+	s1.UpdateMachine("mlab1.abc01.measurement-lab.org", EnterMaintenance, "2", "mlab-oti")
 	rtx.Must(s1.Write(), "Could not save state")
 
 	s2, err := New(dir + "/savedstate.json")

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -25,7 +25,7 @@ var (
 	Machine = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gmx_machine_maintenance",
-			Help: "Whether a machine is in maitenance mode or not.",
+			Help: "Whether a machine is in maintenance mode or not.",
 		},
 		[]string{
 			"machine",


### PR DESCRIPTION
This PR intends to make GMX compatible with v2 node names.

With this PR, state file keys are now short node names with a dash e.g., `mlab1-abc01` instead of FQDNs. Prometheus will now export metrics for both v1 and v2 node names to ease the transition from v1 to v2 names. Once we are completely transitioned to v2 nodes names, this repo can be updated to only publish v2 metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/35)
<!-- Reviewable:end -->
