### PR TITLE
Restores state file using correct FQDNs for node and machine metric labels.

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	// Read state and secrets off the disk.
-	state, err := maintenancestate.New(*fStateFilePath)
+	state, err := maintenancestate.New(*fStateFilePath, *fProject)
 	if err != nil {
 		// TODO: Should this be a fatal error, or is this okay?
 		log.Printf("WARNING: Failed to open state file %s: %s", *fStateFilePath, err)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -283,7 +283,7 @@ func TestReceiveHook(t *testing.T) {
 				test.stateFile = dir + "/" + test.name
 			}
 			ioutil.WriteFile(test.stateFile, []byte(test.initialState), 0644)
-			state, _ := maintenancestate.New(test.stateFile)
+			state, _ := maintenancestate.New(test.stateFile, "mlab-oti")
 			h := New(state, githubSecret, "mlab-oti")
 			sig := generateSignature(test.secretKey, []byte(test.payload))
 			req, err := http.NewRequest("POST", "/webhook", strings.NewReader(string(test.payload)))
@@ -303,7 +303,7 @@ func TestReceiveHook(t *testing.T) {
 			}
 			if test.expectedStatus == http.StatusOK {
 				rtx.Must(ioutil.WriteFile(dir+"/expectedstate.json", []byte(test.expectedState), 0644), "Could not write golden state")
-				savedState, _ := maintenancestate.New(dir + "/expectedstate.json")
+				savedState, _ := maintenancestate.New(dir+"/expectedstate.json", "mlab-oti")
 				savedState.Write()
 				expectedStateBytes, _ := ioutil.ReadFile(dir + "/expectedstate.json")
 				test.expectedState = string(expectedStateBytes)
@@ -405,7 +405,7 @@ func TestParseMessage(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			rtx.Must(ioutil.WriteFile(dir+"/"+test.name, []byte(savedState), 0644), "Could not write state to tempfile")
-			s, err := maintenancestate.New(dir + "/" + test.name)
+			s, err := maintenancestate.New(dir+"/"+test.name, "mlab-oti")
 			rtx.Must(err, "Could not restore state")
 			h := handler{
 				state:   s,

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -49,7 +49,7 @@ func TestUpdateMachine(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s, err := New(dir + "/state.json")
+	s, err := New(dir+"/state.json", "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
 
 	s.UpdateMachine("mlab3-def01", EnterMaintenance, "13", "mlab-oti")
@@ -75,7 +75,7 @@ func TestUpdateSite(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s, err := New(dir + "/state.json")
+	s, err := New(dir+"/state.json", "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
 
 	if _, ok := s.state.Sites["def01"]; ok {
@@ -154,7 +154,7 @@ func TestCloseIssue(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s, err := New(dir + "/state.json")
+	s, err := New(dir+"/state.json", "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
 
 	tests := []struct {
@@ -184,7 +184,7 @@ func TestCloseIssue(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		rtx.Must(s.Restore(), "Could not restore state from tempfile")
+		rtx.Must(s.Restore("mlab-oti"), "Could not restore state from tempfile")
 
 		totalEntitiesBefore := len(s.state.Machines) + len(s.state.Sites)
 		mods := s.CloseIssue(test.issue, "mlab-oti")
@@ -209,7 +209,7 @@ func TestRestore(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s, err := New(dir + "/state.json")
+	s, err := New(dir+"/state.json", "mlab-oti")
 	rtx.Must(err, "Could not restore state")
 	expectedMachines := 11
 	expectedSites := 2
@@ -225,13 +225,13 @@ func TestRestore(t *testing.T) {
 	}
 
 	// Now exercise the error cases
-	s2, err := New(dir + "/doesnotexist.json")
+	s2, err := New(dir+"/doesnotexist.json", "mlab-oti")
 	if s2 == nil || err == nil {
 		t.Error("Should have received a non-nil state and a non-nil error, but got:", s2, err)
 	}
 
 	rtx.Must(ioutil.WriteFile(dir+"/badcontents.json", []byte("This is not json"), 0644), "Could not write bad data for test")
-	s3, err := New(dir + "/badcontents.json")
+	s3, err := New(dir+"/badcontents.json", "mlab-oti")
 	if s3 == nil || err == nil {
 		t.Error("Should have received a non-nil state and a non-nil error, but got:", s3, err)
 	}
@@ -243,12 +243,12 @@ func TestWrite(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/savedstate.json", []byte(savedState), 0644), "Could not write to file")
 
-	s1, err := New(dir + "/savedstate.json")
+	s1, err := New(dir+"/savedstate.json", "mlab-oti")
 	rtx.Must(err, "Could not restore state for s1")
 	s1.UpdateMachine("mlab1-abc01", EnterMaintenance, "2", "mlab-oti")
 	rtx.Must(s1.Write(), "Could not save state")
 
-	s2, err := New(dir + "/savedstate.json")
+	s2, err := New(dir+"/savedstate.json", "mlab-oti")
 	rtx.Must(err, "Could not restore state for s2")
 	if !reflect.DeepEqual(*s2, *s1) {
 		t.Error("The state was not the same after write/restore:", s1, s2)


### PR DESCRIPTION
Resolves #36.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/37)
<!-- Reviewable:end -->
