### PR TITLE
Removes some v1->v2 transitional logic that is no longer necessary.

### DIFF
--- a/maintenancestate/state.go
+++ b/maintenancestate/state.go
@@ -83,12 +83,9 @@ func updateMetrics(mapKey string, project string, action Action, metricState *pr
 	// If this is a machine state, then we need to pass mapKey twice, once for the
 	// "machine" label and once for the "node" label.
 	if strings.HasPrefix(mapKey, "mlab") {
-		// Construct and add labels for v1 and v2 names.
-		// TODO(kinkade): once we have migrated 100% to v2 names, this duplication can be removed.
-		machineLabelV1 := strings.Replace(mapKey, "-", ".", 1) + ".measurement-lab.org"
-		machineLabelV2 := strings.Replace(mapKey, ".", "-", 1) + "." + project + ".measurement-lab.org"
-		metricState.WithLabelValues(machineLabelV1, machineLabelV1).Set(action.StatusValue())
-		metricState.WithLabelValues(machineLabelV2, machineLabelV2).Set(action.StatusValue())
+		// Construct and add labels for the machine.
+		machineLabel := strings.Replace(mapKey, ".", "-", 1) + "." + project + ".measurement-lab.org"
+		metricState.WithLabelValues(machineLabel, machineLabel).Set(action.StatusValue())
 	} else {
 		metricState.WithLabelValues(mapKey).Set(action.StatusValue())
 	}


### PR DESCRIPTION
The platform is now 100% migrated to v2 names, and this logic is no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/38)
<!-- Reviewable:end -->
