### PR TITLE
Integrates new "sites" package into the rest of GMX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 WORKDIR /go/src/github.com/m-lab/github-maintenance-exporter
 ADD . ./
 RUN CGO_ENABLED=0 go install -v .

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/m-lab/github-maintenance-exporter
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/m-lab/go v0.1.49
+	github.com/m-lab/go v0.1.51
 	github.com/prometheus/client_golang v1.12.2
 )
 
@@ -19,6 +19,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.35.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
+	golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/m-lab/go v0.1.49 h1:4Byc76/pYDOYEPLZ/l4emH08QS0zimmj+h7W8iL4r/M=
-github.com/m-lab/go v0.1.49/go.mod h1:woT26L9Hf07juZGHe7Z4WveV7MM6NS6vQaaWzRQnab4=
+github.com/m-lab/go v0.1.51 h1:cCliPixVGCcp7K2IqF3f6Ax7I62Fg4LmU0dLlMRCF5M=
+github.com/m-lab/go v0.1.51/go.mod h1:woT26L9Hf07juZGHe7Z4WveV7MM6NS6vQaaWzRQnab4=
 github.com/m-lab/uuid-annotator v0.4.1/go.mod h1:f/zvgcc5A3HQ1Y63HWpbBVXNcsJwQ4uRIOqsF/nyto8=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -350,6 +350,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4kVNokFwDDyWh/3rGY+I=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -159,7 +159,6 @@ func (h *handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	resp.WriteHeader(status)
-	return
 }
 
 // New creates an http.Handler for receiving github webhook events to update the maintenance state.

--- a/maintenancestate/state.go
+++ b/maintenancestate/state.go
@@ -4,6 +4,7 @@
 package maintenancestate
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -33,6 +34,12 @@ func (a Action) StatusValue() float64 {
 	return float64(int(a) - 1)
 }
 
+// Sites defines a new interface for interacting with the sites package.
+type Sites interface {
+	Reload(ctx context.Context) error
+	Machines(site string) ([]string, error)
+}
+
 // This is the state that is serialized to disk.
 type state struct {
 	Machines, Sites map[string][]string
@@ -42,6 +49,7 @@ type state struct {
 type MaintenanceState struct {
 	state    state
 	filename string
+	sites    Sites
 }
 
 // Looks for a string a slice.
@@ -174,20 +182,15 @@ func (ms *MaintenanceState) UpdateMachine(machine string, action Action, issue s
 
 // UpdateSite causes a whole site to enter or exit maintenance mode.
 func (ms *MaintenanceState) UpdateSite(site string, action Action, issue string, project string) int {
-	var nodes []string
 	mods := updateState(ms.state.Sites, site, metrics.Site, issue, action, project)
 	// If a site is entering or leaving maintenance, automatically add/remove
 	// the project-appropriate nodes to/from maintenance.
-	switch project {
-	case "mlab-sandbox":
-		nodes = []string{"1", "2", "3", "4"}
-	case "mlab-staging":
-		nodes = []string{"4"}
-	case "mlab-oti":
-		nodes = []string{"1", "2", "3"}
+	machines, err := ms.sites.Machines(site)
+	if err != nil {
+		log.Printf("ERROR: could not put site into maintenance: %v", err)
 	}
-	for _, num := range nodes {
-		machine := "mlab" + num + "-" + site
+	for _, m := range machines {
+		machine := m + "-" + site
 		mods += ms.UpdateMachine(machine, action, issue, project)
 	}
 	log.Println("Mods is", mods)
@@ -215,13 +218,14 @@ func (ms *MaintenanceState) CloseIssue(issue string, project string) int {
 
 // New creates a MaintenanceState based on the passed-in filename. If it can't
 // be restored from disk, it also generates an error.
-func New(filename string, project string) (*MaintenanceState, error) {
+func New(filename string, sites Sites, project string) (*MaintenanceState, error) {
 	s := &MaintenanceState{
 		state: state{
 			Machines: make(map[string][]string),
 			Sites:    make(map[string][]string),
 		},
 		filename: filename,
+		sites:    sites,
 	}
 	err := s.Restore(project)
 	if err != nil {

--- a/maintenancestate/state.go
+++ b/maintenancestate/state.go
@@ -182,13 +182,15 @@ func (ms *MaintenanceState) UpdateMachine(machine string, action Action, issue s
 
 // UpdateSite causes a whole site to enter or exit maintenance mode.
 func (ms *MaintenanceState) UpdateSite(site string, action Action, issue string, project string) int {
-	mods := updateState(ms.state.Sites, site, metrics.Site, issue, action, project)
-	// If a site is entering or leaving maintenance, automatically add/remove
-	// the project-appropriate nodes to/from maintenance.
+	// Enforce that the site actually exists.
 	machines, err := ms.sites.Machines(site)
 	if err != nil {
-		log.Printf("ERROR: could not put site into maintenance: %v", err)
+		log.Printf("ERROR: could not update site %s: %v", site, err)
+		return 0
 	}
+	mods := updateState(ms.state.Sites, site, metrics.Site, issue, action, project)
+	// If a site is entering or leaving maintenance, automatically add/remove
+	// the site's machines to/from maintenance.
 	for _, m := range machines {
 		machine := m + "-" + site
 		mods += ms.UpdateMachine(machine, action, issue, project)

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -2,6 +2,7 @@ package maintenancestate
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -43,6 +44,13 @@ type FakeCachingClient struct {
 
 func (f *FakeCachingClient) Machines(site string) ([]string, error) {
 	switch site {
+	case "abc01", "abc02", "def01", "uvw03":
+		return []string{
+			"mlab1",
+			"mlab2",
+			"mlab3",
+			"mlab4",
+		}, nil
 	case "vir01":
 		return []string{
 			"mlab1",
@@ -53,12 +61,7 @@ func (f *FakeCachingClient) Machines(site string) ([]string, error) {
 			"mlab3",
 		}, nil
 	default:
-		return []string{
-			"mlab1",
-			"mlab2",
-			"mlab3",
-			"mlab4",
-		}, nil
+		return []string{}, errors.New("site not found")
 	}
 }
 
@@ -204,6 +207,11 @@ func TestUpdateSite(t *testing.T) {
 		if _, ok := s.state.Machines[m]; ok {
 			t.Errorf("Should not have a machine entry for %s", m)
 		}
+	}
+	// Test updating a non-existent site.
+	mods := s.UpdateSite("not88", EnterMaintenance, "48", "mlab-oti")
+	if mods != 0 {
+		t.Errorf("Expected 0 modifications for non-existent site, but got: %d", mods)
 	}
 }
 

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -1,6 +1,7 @@
 package maintenancestate
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -33,6 +34,38 @@ var savedState = `
 	}
 `
 
+var cachingClient = &FakeCachingClient{}
+
+// FakeCachingClient implements the maintenancestate.Sites interface for testing.
+type FakeCachingClient struct {
+	Sites map[string][]string
+}
+
+func (f *FakeCachingClient) Machines(site string) ([]string, error) {
+	switch site {
+	case "vir01":
+		return []string{
+			"mlab1",
+		}, nil
+	case "odd02":
+		return []string{
+			"mlab2",
+			"mlab3",
+		}, nil
+	default:
+		return []string{
+			"mlab1",
+			"mlab2",
+			"mlab3",
+			"mlab4",
+		}, nil
+	}
+}
+
+func (f *FakeCachingClient) Reload(ctx context.Context) error {
+	return nil
+}
+
 func TestActionStatus(t *testing.T) {
 	if EnterMaintenance.StatusValue() != 1 || LeaveMaintenance.StatusValue() != 0 {
 		t.Error(EnterMaintenance.StatusValue(), "and", LeaveMaintenance.StatusValue(), "should be 1 and 0")
@@ -49,7 +82,7 @@ func TestUpdateMachine(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s, err := New(dir+"/state.json", "mlab-oti")
+	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
 
 	s.UpdateMachine("mlab3-def01", EnterMaintenance, "13", "mlab-oti")
@@ -75,7 +108,7 @@ func TestUpdateSite(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s, err := New(dir+"/state.json", "mlab-oti")
+	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
 
 	if _, ok := s.state.Sites["def01"]; ok {
@@ -118,33 +151,59 @@ func TestUpdateSite(t *testing.T) {
 	if len(s.state.Sites["def01"]) != 1 {
 		t.Error("Should have one issue for def01")
 	}
-	if _, ok := s.state.Machines["mlab1-def01"]; ok {
-		t.Error("Should have nothing for mlab1-def01")
+	if len(s.state.Machines["mlab3-def01"]) != 2 {
+		t.Error("Should have two issues for mlab3-def01")
 	}
-	if _, ok := s.state.Machines["mlab2-def01"]; ok {
-		t.Error("Should have nothing for mlab2-def01")
-	}
-	if len(s.state.Machines["mlab3-def01"]) != 1 {
-		t.Error("Should have one issue for mlab3-def01")
-	}
-	if len(s.state.Machines["mlab4-def01"]) != 2 {
-		t.Error("Should have two issues for mlab4-def01")
+	if len(s.state.Machines["mlab4-def01"]) != 1 {
+		t.Error("Should have one issue for mlab4-def01")
 	}
 	s.UpdateSite("def01", EnterMaintenance, "7", "mlab-sandbox")
 	if len(s.state.Sites["def01"]) != 2 {
 		t.Error("Should have two issues for def01")
 	}
-	if len(s.state.Machines["mlab1-def01"]) != 1 {
-		t.Error("Should have one issue for mlab1-def01")
+	if len(s.state.Machines["mlab1-def01"]) != 2 {
+		t.Error("Should have two issues for mlab1-def01")
 	}
-	if len(s.state.Machines["mlab2-def01"]) != 1 {
-		t.Error("Should have one issue for mlab2-def01")
+	if len(s.state.Machines["mlab2-def01"]) != 2 {
+		t.Error("Should have two issues for mlab2-def01")
 	}
-	if len(s.state.Machines["mlab3-def01"]) != 2 {
-		t.Error("Should have two issues for mlab3-def01")
+	if len(s.state.Machines["mlab3-def01"]) != 3 {
+		t.Error("Should have three issues for mlab3-def01")
 	}
-	if len(s.state.Machines["mlab4-def01"]) != 3 {
-		t.Error("Should have three issues for mlab4-def01")
+	if len(s.state.Machines["mlab4-def01"]) != 2 {
+		t.Error("Should have two issues for mlab4-def01")
+	}
+	// Test putting a single-machine virtual site in and out of maintenance.
+	s.UpdateSite("vir01", EnterMaintenance, "74", "mlab-oti")
+	if _, ok := s.state.Machines["mlab1-vir01"]; !ok {
+		t.Error("Should have a machine entry for mlab1-vir01")
+	}
+	for _, m := range []string{"mlab2-vir01", "mlab3-vir01", "mlab4-vir01"} {
+		if _, ok := s.state.Machines[m]; ok {
+			t.Errorf("Should not have a machine entry for %s", m)
+		}
+	}
+	s.UpdateSite("vir01", LeaveMaintenance, "74", "mlab-oti")
+	if _, ok := s.state.Machines["mlab1-vir01"]; ok {
+		t.Error("Should not have a machine entry for mlab1-vir01")
+	}
+	// Test putting an oddball two-machine site in and out of maintenance.
+	s.UpdateSite("odd02", EnterMaintenance, "48", "mlab-oti")
+	for _, m := range []string{"mlab2-odd02", "mlab3-odd02"} {
+		if _, ok := s.state.Machines[m]; !ok {
+			t.Errorf("Should have a machine entry for %s", m)
+		}
+	}
+	for _, m := range []string{"mlab1-odd02", "mlab4-odd02"} {
+		if _, ok := s.state.Machines[m]; ok {
+			t.Errorf("Should not have a machine entry for %s", m)
+		}
+	}
+	s.UpdateSite("odd02", LeaveMaintenance, "48", "mlab-oti")
+	for _, m := range []string{"mlab2-odd02", "mlab3-odd02"} {
+		if _, ok := s.state.Machines[m]; ok {
+			t.Errorf("Should not have a machine entry for %s", m)
+		}
 	}
 }
 
@@ -154,7 +213,7 @@ func TestCloseIssue(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s, err := New(dir+"/state.json", "mlab-oti")
+	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
 
 	tests := []struct {
@@ -209,7 +268,7 @@ func TestRestore(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
-	s, err := New(dir+"/state.json", "mlab-oti")
+	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not restore state")
 	expectedMachines := 11
 	expectedSites := 2
@@ -225,13 +284,13 @@ func TestRestore(t *testing.T) {
 	}
 
 	// Now exercise the error cases
-	s2, err := New(dir+"/doesnotexist.json", "mlab-oti")
+	s2, err := New(dir+"/doesnotexist.json", cachingClient, "mlab-oti")
 	if s2 == nil || err == nil {
 		t.Error("Should have received a non-nil state and a non-nil error, but got:", s2, err)
 	}
 
 	rtx.Must(ioutil.WriteFile(dir+"/badcontents.json", []byte("This is not json"), 0644), "Could not write bad data for test")
-	s3, err := New(dir+"/badcontents.json", "mlab-oti")
+	s3, err := New(dir+"/badcontents.json", cachingClient, "mlab-oti")
 	if s3 == nil || err == nil {
 		t.Error("Should have received a non-nil state and a non-nil error, but got:", s3, err)
 	}
@@ -243,12 +302,12 @@ func TestWrite(t *testing.T) {
 	defer os.RemoveAll(dir)
 	rtx.Must(ioutil.WriteFile(dir+"/savedstate.json", []byte(savedState), 0644), "Could not write to file")
 
-	s1, err := New(dir+"/savedstate.json", "mlab-oti")
+	s1, err := New(dir+"/savedstate.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not restore state for s1")
 	s1.UpdateMachine("mlab1-abc01", EnterMaintenance, "2", "mlab-oti")
 	rtx.Must(s1.Write(), "Could not save state")
 
-	s2, err := New(dir+"/savedstate.json", "mlab-oti")
+	s2, err := New(dir+"/savedstate.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not restore state for s2")
 	if !reflect.DeepEqual(*s2, *s1) {
 		t.Error("The state was not the same after write/restore:", s1, s2)


### PR DESCRIPTION
Currently, GMX assumes that every site has 4 machines. With this assumption, every time a site is put into maintenance, 4 machine maintenances are created for each of the 4 machines the site supposed has. However, with the introduction of virtual sites, it is no longer guaranteed that every site will have 4 machines. It might otherwise be benign that a virtual site with only 1 machine has maintenance metrics for 4 machines, except for the way that mlab-ns queries for machines that are healthy. The composite queries that mlab-ns runs will return no metrics for a non-existent machine at a site, _except_ for a metric from the GMX for that non-existent machine. When a non-existent machine at a virtual site is taken out of maintenance mode, then the query by mlab-ns will return a healthy signal for that non-existent machine, causing mlab-ns to possibly send traffic to a non-existent machine.

With this change, GMX will only put machines into maintenance that actually exist at a site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/41)
<!-- Reviewable:end -->
