### PR TITLE
Remove state for retired sites

### DIFF
--- a/gmx.go
+++ b/gmx.go
@@ -122,8 +122,8 @@ func main() {
 			if err != nil {
 				log.Printf("Failed to reload the siteinfo data: %v", err)
 			}
+			state.Prune(*fProject)
 		}
-		state.Prune(*fProject)
 	}()
 
 	// When the context is canceled, stop serving.

--- a/gmx.go
+++ b/gmx.go
@@ -124,6 +124,7 @@ func main() {
 				log.Printf("Failed to reload the siteinfo data: %v", err)
 			}
 		}
+		state.Prune(*fProject)
 	}()
 
 	// When the context is canceled, stop serving.

--- a/gmx.go
+++ b/gmx.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -54,7 +53,7 @@ func MustReadGithubSecret(filename string) []byte {
 	// Read it from a file or the environment.
 	if filename != "" {
 		var err error
-		secret, err = ioutil.ReadFile(filename)
+		secret, err = os.ReadFile(filename)
 		rtx.Must(err, "ERROR: Could not read file %s", filename)
 	} else {
 		secret = []byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))

--- a/gmx.go
+++ b/gmx.go
@@ -95,6 +95,9 @@ func main() {
 		log.Printf("WARNING: Failed to open state file %s: %s", *fStateFilePath, err)
 	}
 
+	// Prune the loaded statefile of state for sites/machine that no longer exist.
+	state.Prune(*fProject)
+
 	githubSecret := MustReadGithubSecret(*fGitHubSecretPath)
 
 	// Add handlers to the default handler.

--- a/gmx_test.go
+++ b/gmx_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -32,7 +32,7 @@ func TestRootHandler(t *testing.T) {
 			"TestRootHandler", rec.Code, expectedStatus)
 	}
 
-	bytes, _ := ioutil.ReadAll(rec.Body)
+	bytes, _ := io.ReadAll(rec.Body)
 	payload := string(bytes)
 	if string(payload) != expectedPayload {
 		t.Errorf("rootHandler(): test %s: unexpected return text: got %s; want %s",
@@ -41,10 +41,10 @@ func TestRootHandler(t *testing.T) {
 }
 
 func TestGithubSecretFromFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestGithubSecretFromFile")
+	dir, err := os.MkdirTemp("", "TestGithubSecretFromFile")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
-	rtx.Must(ioutil.WriteFile(dir+"/secret", []byte("test"), 0644), "Could not create test secret")
+	rtx.Must(os.WriteFile(dir+"/secret", []byte("test"), 0644), "Could not create test secret")
 	b := MustReadGithubSecret(dir + "/secret")
 	if !reflect.DeepEqual(b, []byte("test")) {
 		t.Errorf("%v != %v", b, "test")
@@ -61,10 +61,10 @@ func TestGithubSecretFromEnv(t *testing.T) {
 }
 
 func TestGithubSecretFromEmptyFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestGithubSecretFromEmptyFile")
+	dir, err := os.MkdirTemp("", "TestGithubSecretFromEmptyFile")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
-	rtx.Must(ioutil.WriteFile(dir+"/secret", []byte{}, 0644), "Could not create test secret")
+	rtx.Must(os.WriteFile(dir+"/secret", []byte{}, 0644), "Could not create test secret")
 
 	logFatal = func(...interface{}) { panic("testerror") }
 	defer func() {
@@ -92,10 +92,10 @@ func TestMainBadProject(t *testing.T) {
 }
 
 func TestMainViaSmokeTest(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestMainViaSmokeTest")
+	dir, err := os.MkdirTemp("", "TestMainViaSmokeTest")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
-	rtx.Must(ioutil.WriteFile(dir+"/secret", []byte("test"), 0644), "Could not create test secret")
+	rtx.Must(os.WriteFile(dir+"/secret", []byte("test"), 0644), "Could not create test secret")
 
 	logFatal = func(...interface{}) { panic("testerror") }
 	defer func() {

--- a/maintenancestate/state.go
+++ b/maintenancestate/state.go
@@ -6,8 +6,8 @@ package maintenancestate
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/m-lab/github-maintenance-exporter/metrics"
@@ -130,7 +130,7 @@ func updateState(stateMap map[string][]string, mapKey string, metricState *prome
 
 // Restore the maintenance state from disk.
 func (ms *MaintenanceState) Restore(project string) error {
-	data, err := ioutil.ReadFile(ms.filename)
+	data, err := os.ReadFile(ms.filename)
 	if err != nil {
 		log.Printf("ERROR: Failed to read state data from %s: %s", ms.filename, err)
 		metrics.Error.WithLabelValues("readfile", "maintenancestate.Restore").Inc()
@@ -164,7 +164,7 @@ func (ms *MaintenanceState) Write() error {
 	data, err := json.MarshalIndent(ms.state, "", "    ")
 	rtx.Must(err, "Could not marshal MaintenanceState to a buffer.  This should never happen.")
 
-	err = ioutil.WriteFile(ms.filename, data, 0664)
+	err = os.WriteFile(ms.filename, data, 0664)
 	if err != nil {
 		log.Printf("ERROR: Failed to write state to %s: %s", ms.filename, err)
 		metrics.Error.WithLabelValues("writefile", "maintenancestate.Write").Add(1)

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -3,6 +3,7 @@ package maintenancestate
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -22,6 +23,11 @@ var savedState = `
 			"mlab4-abc02": ["8"],
 			"mlab3-def01": ["5"],
 			"mlab4-def01": ["20"],
+			"mlab1-ret0t": ["7"],
+			"mlab2-ret0t": ["7"],
+			"mlab3-ret0t": ["7"],
+			"mlab4-ret0t": ["7"],
+			"mlab2-ret2t": ["12", "15"],
 			"mlab1-uvw03": ["4", "11"],
 			"mlab2-uvw03": ["4", "11"],
 			"mlab3-uvw03": ["4", "11"],
@@ -29,6 +35,7 @@ var savedState = `
 		},
 		"Sites": {
 			"abc02": ["8"],
+			"ret0t": ["7"],
 			"uvw03": ["4", "11"]
 		}
 	}
@@ -75,7 +82,15 @@ func TestActionStatus(t *testing.T) {
 }
 
 func TestUpdateStateWithBadValue(t *testing.T) {
-	updateState(nil, "", nil, "", -1, "no-project") // The -1 should not be a legal action.
+	dir, err := os.MkdirTemp("", "TestUpdateStateSWithBadValue")
+	rtx.Must(err, "Could not create tempdir")
+	defer os.RemoveAll(dir)
+	rtx.Must(os.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
+
+	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
+	rtx.Must(err, "Could not read from tmpfile")
+
+	s.updateState(nil, "", nil, "", -1, "no-project") // The -1 should not be a legal action.
 }
 
 func TestUpdateMachine(t *testing.T) {
@@ -269,6 +284,50 @@ func TestCloseIssue(t *testing.T) {
 	}
 }
 
+func TestPrune(t *testing.T) {
+	dir, err := os.MkdirTemp("", "TestPrune")
+	rtx.Must(err, "Could not create tempdir")
+	defer os.RemoveAll(dir)
+	rtx.Must(os.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
+
+	s, err := New(dir+"/state.json", cachingClient, "mlab-sandbox")
+	rtx.Must(err, "Could not read from tmpfile")
+
+	// Record the length of Sites and Machines. Our test data has 1 retired site
+	// (with 4 machines), and one retired machine. We'll use these counts to be
+	// sure that Prune() remove more sites and/or machines than we expected.
+	siteCount := len(s.state.Sites)
+	machineCount := len(s.state.Machines)
+
+	s.Prune("mlab-sandbox")
+
+	if _, ok := s.state.Sites["ret0t"]; ok {
+		t.Error("TestPrune(): should NOT have ret0t in sites.")
+	}
+
+	for i := 1; i <= 4; i++ {
+		if _, ok := s.state.Machines[fmt.Sprintf("mlab%d-ret0t", i)]; ok {
+			t.Errorf("TestPrune(): should NOT have mlab%d-ret0t in machines.", i)
+		}
+
+	}
+
+	if _, ok := s.state.Machines["mlab2-ret2t"]; ok {
+		t.Error("TestPrune(): should NOT have mlab2-ret2t in machines.")
+	}
+
+	if (siteCount - 1) != len(s.state.Sites) {
+		t.Errorf("TestPrune(): expected site count of %d, got %d", (siteCount - 1), len(s.state.Sites))
+	}
+
+	if (machineCount - 5) != len(s.state.Machines) {
+		t.Errorf("TestPrune(): expected site count of %d, got %d", (machineCount - 5), len(s.state.Machines))
+	}
+
+	os.Remove(dir + "/state.json")
+	s.Prune("mlab-sandbox")
+}
+
 func TestRestore(t *testing.T) {
 	dir, err := os.MkdirTemp("", "TestRestore")
 	rtx.Must(err, "Could not create tempdir")
@@ -277,8 +336,8 @@ func TestRestore(t *testing.T) {
 
 	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not restore state")
-	expectedMachines := 11
-	expectedSites := 2
+	expectedMachines := 16
+	expectedSites := 3
 
 	if len(s.state.Machines) != expectedMachines {
 		t.Errorf("restoreState(): Expected %d restored machines; have %d.",
@@ -316,7 +375,7 @@ func TestWrite(t *testing.T) {
 
 	s2, err := New(dir+"/savedstate.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not restore state for s2")
-	if !reflect.DeepEqual(*s2, *s1) {
+	if !reflect.DeepEqual(s2, s1) {
 		t.Error("The state was not the same after write/restore:", s1, s2)
 	}
 	if strings.Join(s2.state.Machines["mlab1-abc01"], " ") != "1 2" {

--- a/maintenancestate/state_test.go
+++ b/maintenancestate/state_test.go
@@ -3,7 +3,6 @@ package maintenancestate
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -80,10 +79,10 @@ func TestUpdateStateWithBadValue(t *testing.T) {
 }
 
 func TestUpdateMachine(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestUpdateMachine")
+	dir, err := os.MkdirTemp("", "TestUpdateMachine")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
-	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
+	rtx.Must(os.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
 	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
@@ -106,10 +105,10 @@ func TestUpdateMachine(t *testing.T) {
 }
 
 func TestUpdateSite(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestUpdateSite")
+	dir, err := os.MkdirTemp("", "TestUpdateSite")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
-	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
+	rtx.Must(os.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
 	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
@@ -216,10 +215,10 @@ func TestUpdateSite(t *testing.T) {
 }
 
 func TestCloseIssue(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestCloseIssue")
+	dir, err := os.MkdirTemp("", "TestCloseIssue")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
-	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
+	rtx.Must(os.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
 	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not read from tmpfile")
@@ -271,10 +270,10 @@ func TestCloseIssue(t *testing.T) {
 }
 
 func TestRestore(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestRestore")
+	dir, err := os.MkdirTemp("", "TestRestore")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
-	rtx.Must(ioutil.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
+	rtx.Must(os.WriteFile(dir+"/state.json", []byte(savedState), 0644), "Could not write state to tempfile")
 
 	s, err := New(dir+"/state.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not restore state")
@@ -297,7 +296,7 @@ func TestRestore(t *testing.T) {
 		t.Error("Should have received a non-nil state and a non-nil error, but got:", s2, err)
 	}
 
-	rtx.Must(ioutil.WriteFile(dir+"/badcontents.json", []byte("This is not json"), 0644), "Could not write bad data for test")
+	rtx.Must(os.WriteFile(dir+"/badcontents.json", []byte("This is not json"), 0644), "Could not write bad data for test")
 	s3, err := New(dir+"/badcontents.json", cachingClient, "mlab-oti")
 	if s3 == nil || err == nil {
 		t.Error("Should have received a non-nil state and a non-nil error, but got:", s3, err)
@@ -305,10 +304,10 @@ func TestRestore(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestWrite")
+	dir, err := os.MkdirTemp("", "TestWrite")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
-	rtx.Must(ioutil.WriteFile(dir+"/savedstate.json", []byte(savedState), 0644), "Could not write to file")
+	rtx.Must(os.WriteFile(dir+"/savedstate.json", []byte(savedState), 0644), "Could not write to file")
 
 	s1, err := New(dir+"/savedstate.json", cachingClient, "mlab-oti")
 	rtx.Must(err, "Could not restore state for s1")


### PR DESCRIPTION
Today, GMX will refuse to do any sort of operation on a site that doesn't exist in siteinfo. This is problematic for retired sites. We generally put sites into maintenance before we retire them, then we remove them from siteinfo. This causes orphaned state in GMX that cannot be removed. This pollutes GMX metrics, making it seems like a lot of sites are in maintenance, but in reality they mostly for retired sites. This also had the effect of breaking mlab-ns site status updates. The mlab-ns update process has a check that will refuse to update save state if more than a certain percentage of experiments are down (and this calculation includes sites in GMX). With so many retired sites hanging around in GMX, this has caused mlab-ns to tigger the safeguard and refuse to update state based on Prometheus monitoring.

This PR introduces a new `maintenancestate.Prune()` method that is scheduled to run on startup, and whenever siteinfo data is periodically reloaded. The new function iterates over all active state and will remove it if it doesn't find a corresponding entry for the site in siteinfo.

This PR removes the mutex.Lock from the handler package, and put it in the maintenancestate package instead, since it's purpose in the handler package was to prevent concurrent webhook request from racing to update state. The lock in its new location allows the Prune() function also set a lock, preventing it from racing with incoming webhooks.

Additionally, this PR replaces all deprecated uses package io/ioutil with their corresponding "os" package replacements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/github-maintenance-exporter/46)
<!-- Reviewable:end -->
